### PR TITLE
Add new style and delete style buttons

### DIFF
--- a/ai_diffusion/style.py
+++ b/ai_diffusion/style.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import json
-import os
 from pathlib import Path
 from PyQt5.QtCore import QObject, pyqtSignal
 
@@ -195,7 +194,14 @@ class Styles(QObject):
     def default(self):
         return self[0]
     
-    def create(self, name: str) -> Style:
+    def create(self, name: str = "style") -> Style:
+        if Path(self.folder / f"{name}.json").exists():
+            i = 1
+            basename = name
+            while Path(self.folder / f"{basename}_{i}.json").exists():
+                i += 1
+            name = f"{basename}_{i}"
+        
         new_style = Style(self.folder / f"{name}.json")
         new_style.name = name
         self._list.append(new_style)
@@ -205,7 +211,7 @@ class Styles(QObject):
     
     def delete(self, style: Style):
         self._list.remove(style)
-        os.remove(style.filepath)
+        style.filepath.unlink()
         self.changed.emit()
 
     def reload(self):

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -5,6 +5,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QDialog,
+    QInputDialog,
     QPushButton,
     QFrame,
     QLabel,
@@ -576,6 +577,16 @@ class StylePresets(SettingsTab):
         self._open_folder_button.setIcon(Krita.instance().icon("document-open"))
         self._open_folder_button.clicked.connect(self._open_folder)
         frame_layout.addWidget(self._open_folder_button)
+        
+        self._create_style_button = QToolButton(self)
+        self._create_style_button.setIcon(Krita.instance().icon("list-add"))
+        self._create_style_button.clicked.connect(self._create_style)
+        frame_layout.addWidget(self._create_style_button)
+        
+        self._delete_style_button = QToolButton(self)
+        self._delete_style_button.setIcon(Krita.instance().icon("deletelayer"))
+        self._delete_style_button.clicked.connect(self._delete_style)
+        frame_layout.addWidget(self._delete_style_button)
 
         self._layout.addWidget(frame)
 
@@ -616,6 +627,17 @@ class StylePresets(SettingsTab):
 
     def update_model_lists(self):
         self._read()
+    
+    def _create_style(self):
+        filename, ok = QInputDialog.getText(self, "New style", "")
+        if ok and filename:
+            self.current_style = Styles.list().create(filename)
+            self._change_style()
+        self._update_style_list()
+            
+    def _delete_style(self):
+        Styles.list().delete(self.current_style)
+        self._update_style_list()
 
     def _open_folder(self):
         QDesktopServices.openUrl(QUrl.fromLocalFile(str(Styles.list().folder)))

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -5,7 +5,6 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QDialog,
-    QInputDialog,
     QPushButton,
     QFrame,
     QLabel,
@@ -627,14 +626,13 @@ class StylePresets(SettingsTab):
 
     def update_model_lists(self):
         self._read()
-    
+
     def _create_style(self):
-        filename, ok = QInputDialog.getText(self, "New style", "")
-        if ok and filename:
-            self.current_style = Styles.list().create(filename)
-            self._change_style()
+        # make sure the new style is in the combobox before setting it as the current style
+        new_style = Styles.list().create()
         self._update_style_list()
-            
+        self.current_style = new_style
+
     def _delete_style(self):
         Styles.list().delete(self.current_style)
         self._update_style_list()


### PR DESCRIPTION
Closes #7 

Adds create style and delete style buttons.
![image](https://github.com/Acly/krita-ai-diffusion/assets/22294122/83146548-eab2-453f-a78e-47a716d31b68)

The create style opens an input dialog where the new style name can be given.
![image](https://github.com/Acly/krita-ai-diffusion/assets/22294122/438ee0eb-4381-4c54-a335-e15ff8eed481)
After the stlye is created, it becomes the currently selected style.

Delete style removes the currently loaded style. There is NO confirmation dialog currently (I don't need it, but could be added).

In both cases the style list is refreshed.

