### PR TITLE
Support Apple GPU (MPS)

### DIFF
--- a/ai_diffusion/server.py
+++ b/ai_diffusion/server.py
@@ -215,7 +215,7 @@ class Server:
         temp_comfy_dir = comfy_dir.parent / f"ComfyUI-{resources.comfy_version}"
 
         torch_args = ["torch", "torchvision", "torchaudio"]
-        if self.backend is ServerBackend.cpu:
+        if self.backend is ServerBackend.cpu or self.backend is ServerBackend.mps:
             torch_args += ["--index-url", "https://download.pytorch.org/whl/cpu"]
         elif self.backend is ServerBackend.cuda:
             torch_args += ["--index-url", "https://download.pytorch.org/whl/cu121"]

--- a/ai_diffusion/server.py
+++ b/ai_diffusion/server.py
@@ -375,6 +375,8 @@ class Server:
             args.append("--cpu")
         elif self.backend is ServerBackend.directml:
             args.append("--directml")
+        elif self.backend is ServerBackend.mps:
+            args.append("--force-fp16")
         if settings.server_arguments:
             args += settings.server_arguments.split(" ")
         self._process = await asyncio.create_subprocess_exec(

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -18,6 +18,7 @@ class ServerMode(Enum):
 class ServerBackend(Enum):
     cpu = "Run on CPU"
     cuda = "Use CUDA (NVIDIA GPU)"
+    mps = "Use MPS (Metal Performance Shader)"
     directml = "Use DirectML (GPU)"
 
 

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import os
-import sys
 import json
 from enum import Enum
 from pathlib import Path
@@ -17,10 +16,20 @@ class ServerMode(Enum):
 
 class ServerBackend(Enum):
     cpu = ("Run on CPU", True)
-    cuda = ("Use CUDA (NVIDIA GPU)", sys.platform != 'darwin')
-    mps = ("Use MPS (Metal Performance Shader)", sys.platform == 'darwin')
-    directml = ("Use DirectML (GPU)", sys.platform.startswith("win"))
+    cuda = ("Use CUDA (NVIDIA GPU)", not util.is_macos)
+    mps = ("Use MPS (Metal Performance Shader)", util.is_macos)
+    directml = ("Use DirectML (GPU)", util.is_windows)
 
+    @staticmethod
+    def supported():
+        return [b for b in ServerBackend if b.value[1]]
+
+    @staticmethod
+    def default():
+        if util.is_macos:
+            return ServerBackend.mps
+        else:
+            return ServerBackend.cuda
 
 class PerformancePreset(Enum):
     auto = "Automatic"
@@ -76,7 +85,7 @@ class Settings(QObject):
     )
 
     server_backend: ServerBackend
-    _server_backend = Setting("Server Backend", ServerBackend.cpu)
+    _server_backend = Setting("Server Backend", ServerBackend.default())
 
     server_arguments: str
     _server_arguments = Setting(

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import os
+import sys
 import json
 from enum import Enum
 from pathlib import Path
@@ -8,7 +9,6 @@ from PyQt5.QtCore import QObject, pyqtSignal
 
 from . import util
 
-
 class ServerMode(Enum):
     undefined = -1
     managed = 0
@@ -16,10 +16,10 @@ class ServerMode(Enum):
 
 
 class ServerBackend(Enum):
-    cpu = "Run on CPU"
-    cuda = "Use CUDA (NVIDIA GPU)"
-    mps = "Use MPS (Metal Performance Shader)"
-    directml = "Use DirectML (GPU)"
+    cpu = ("Run on CPU", True)
+    cuda = ("Use CUDA (NVIDIA GPU)", sys.platform != 'darwin')
+    mps = ("Use MPS (Metal Performance Shader)", sys.platform == 'darwin')
+    directml = ("Use DirectML (GPU)", sys.platform.startswith("win"))
 
 
 class PerformancePreset(Enum):
@@ -76,7 +76,7 @@ class Settings(QObject):
     )
 
     server_backend: ServerBackend
-    _server_backend = Setting("Server Backend", ServerBackend.cuda)
+    _server_backend = Setting("Server Backend", ServerBackend.cpu)
 
     server_arguments: str
     _server_arguments = Setting(

--- a/ai_diffusion/ui/server.py
+++ b/ai_diffusion/ui/server.py
@@ -266,8 +266,7 @@ class ServerWidget(QWidget):
         self._progress_info.setStyleSheet("font-style:italic")
         self._progress_info.setVisible(False)
 
-        backend_supported = lambda b: b is not ServerBackend.directml or util.is_windows
-        backends = [b.value for b in ServerBackend if backend_supported(b)]
+        backends = [b.value[0] for b in ServerBackend if b.value[1]]
         self._backend_select = QComboBox(self)
         self._backend_select.addItems(backends)
         self._backend_select.currentIndexChanged.connect(self._change_backend)
@@ -383,7 +382,14 @@ class ServerWidget(QWidget):
             self._location_edit.setText(path)
 
     def _change_backend(self):
-        backend = list(ServerBackend)[self._backend_select.currentIndex()]
+        backends = list(ServerBackend)
+        i, j = 0, 0
+        while i < self._backend_select.currentIndex():
+            i += 1
+            j += 1
+            while not backends[j].value[1]:
+                j += 1
+        backend = backends[j]
         if settings.server_backend != backend:
             self._server.backend = backend
             settings.server_backend = backend
@@ -501,7 +507,15 @@ class ServerWidget(QWidget):
 
     def update(self):
         self._location_edit.setText(settings.server_path)
-        self._backend_select.setCurrentIndex(list(ServerBackend).index(settings.server_backend))
+        backends, i, j = list(ServerBackend), 0, 0
+        while i < len(backends) and backends[i] != settings.server_backend:
+            i += 1
+            try:
+                if backends[i].value[1]:
+                    j += 1
+            except:
+                pass
+        self._backend_select.setCurrentIndex(j)
         self._progress_bar.setVisible(False)
         self._progress_info.setVisible(False)
         self._backend_select.setVisible(True)

--- a/ai_diffusion/ui/server.py
+++ b/ai_diffusion/ui/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from enum import Enum
 from pathlib import Path
 from typing import Optional
+from itertools import accumulate
 from PyQt5.QtCore import Qt, QUrl, pyqtSignal
 from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtWidgets import (
@@ -383,13 +384,11 @@ class ServerWidget(QWidget):
 
     def _change_backend(self):
         backends = list(ServerBackend)
-        i, j = 0, 0
-        while i < self._backend_select.currentIndex():
-            i += 1
-            j += 1
-            while not backends[j].value[1]:
-                j += 1
-        backend = backends[j]
+        indices = list(accumulate([b.value[1] for b in ServerBackend], initial=-1))[1:]
+        try:
+            backend = backends[indices.index(self._backend_select.currentIndex())]
+        except:
+            backend = backends[0]
         if settings.server_backend != backend:
             self._server.backend = backend
             settings.server_backend = backend
@@ -507,15 +506,13 @@ class ServerWidget(QWidget):
 
     def update(self):
         self._location_edit.setText(settings.server_path)
-        backends, i, j = list(ServerBackend), 0, 0
-        while i < len(backends) and backends[i] != settings.server_backend:
-            i += 1
-            try:
-                if backends[i].value[1]:
-                    j += 1
-            except:
-                pass
-        self._backend_select.setCurrentIndex(j)
+        backends = list(ServerBackend)
+        indices = list(accumulate([b.value[1] for b in ServerBackend], initial=-1))[1:]
+        try:
+            index = indices[backends.index(settings.server_backend)]
+        except:
+            index = 0
+        self._backend_select.setCurrentIndex(index)
         self._progress_bar.setVisible(False)
         self._progress_info.setVisible(False)
         self._backend_select.setVisible(True)

--- a/ai_diffusion/ui/server.py
+++ b/ai_diffusion/ui/server.py
@@ -267,9 +267,8 @@ class ServerWidget(QWidget):
         self._progress_info.setStyleSheet("font-style:italic")
         self._progress_info.setVisible(False)
 
-        backends = [b.value[0] for b in ServerBackend if b.value[1]]
         self._backend_select = QComboBox(self)
-        self._backend_select.addItems(backends)
+        self._backend_select.addItems([b.value[0] for b in ServerBackend.supported()])
         self._backend_select.currentIndexChanged.connect(self._change_backend)
 
         self._launch_button = QPushButton("Launch", self)
@@ -383,10 +382,9 @@ class ServerWidget(QWidget):
             self._location_edit.setText(path)
 
     def _change_backend(self):
-        backends = list(ServerBackend)
-        indices = list(accumulate([b.value[1] for b in ServerBackend], initial=-1))[1:]
+        backends = ServerBackend.supported()
         try:
-            backend = backends[indices.index(self._backend_select.currentIndex())]
+            backend = backends[self._backend_select.currentIndex()]
         except:
             backend = backends[0]
         if settings.server_backend != backend:
@@ -506,10 +504,9 @@ class ServerWidget(QWidget):
 
     def update(self):
         self._location_edit.setText(settings.server_path)
-        backends = list(ServerBackend)
-        indices = list(accumulate([b.value[1] for b in ServerBackend], initial=-1))[1:]
+        backends = ServerBackend.supported()
         try:
-            index = indices[backends.index(settings.server_backend)]
+            index = backends.index(settings.server_backend)
         except:
             index = 0
         self._backend_select.setCurrentIndex(index)

--- a/ai_diffusion/util.py
+++ b/ai_diffusion/util.py
@@ -8,13 +8,13 @@ import logging.handlers
 import zipfile
 from typing import Optional, TypeVar
 
-from .image import Extent
-from .settings import settings
-
 T = TypeVar("T")
 
 is_windows = sys.platform.startswith("win")
+is_macos = (sys.platform == 'darwin')
 
+from .image import Extent
+from .settings import settings
 
 def create_logger(name: str, path: Path):
     logger = logging.getLogger(name)


### PR DESCRIPTION
pytorch 2.1 supports Apple silicon GPU (MPS) backend (https://pytorch.org/docs/stable/notes/mps.html) and ComfyUI supports it as well (https://github.com/comfyanonymous/ComfyUI#apple-mac-silicon)

To enable this I made a small change to add mps backend option, which when selected, would make ComfyUI started with --force-fp16 instead of --cpu.

It seems working and improves generation time on Apple silicons.

Start of server log:

```
2023-11-22 19:59:35,244 INFO Total VRAM 8192 MB, total RAM 8192 MB
2023-11-22 19:59:35,621 INFO Set vram state to: SHARED
2023-11-22 19:59:35,622 INFO Device: mps
2023-11-22 19:59:35,622 INFO VAE dtype: torch.float32
2023-11-22 19:59:36,077 INFO Using sub quadratic optimization for cross attention, if you have memory or speed issues try using: --use-split-cross-attention

```
