### PR TITLE
ControlNet ending step support (and scribble update)

### DIFF
--- a/ai_diffusion/comfyworkflow.py
+++ b/ai_diffusion/comfyworkflow.py
@@ -148,15 +148,18 @@ class ComfyWorkflow:
         return self.add("ConditioningCombine", 1, conditioning_1=a, conditioning_2=b)
 
     def apply_controlnet(
-        self, conditioning: Output, controlnet: Output, image: Output, strength=1.0
+        self, positive: Output, negative: Output, controlnet: Output, image: Output, strength=1.0, start_percent=0.0, end_percent=1.0
     ):
         return self.add(
-            "ControlNetApply",
-            1,
-            conditioning=conditioning,
+            "ControlNetApplyAdvanced",
+            2,
+            positive=positive,
+            negative=negative,
             control_net=controlnet,
             image=image,
             strength=strength,
+            start_percent=start_percent,
+            end_percent=end_percent,
         )
 
     def apply_ip_adapter(

--- a/ai_diffusion/resources.py
+++ b/ai_diffusion/resources.py
@@ -374,7 +374,7 @@ _control_filename = {
     },
     ControlMode.scribble: {
         SDVersion.sd15: ["control_v11p_sd15_scribble", "control_lora_rank128_v11p_sd15_scribble"],
-        SDVersion.sdxl: None,
+        SDVersion.sdxl: ["control-lora-sketch-rank", "sai_xl_sketch_"],
     },
     ControlMode.line_art: {
         SDVersion.sd15: ["control_v11p_sd15_lineart", "control_lora_rank128_v11p_sd15_lineart"],

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -117,7 +117,7 @@ class Settings(QObject):
 
     show_control_end: bool
     _show_control_end = Setting(
-        "Control end step", True, "Show control end step ratio"
+        "Control ending step", False, "Show control ending step ratio"
     )
 
     history_size: int

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -115,6 +115,11 @@ class Settings(QObject):
         "Negative Prompt", False, "Show text editor to describe things to avoid"
     )
 
+    show_control_end: bool
+    _show_control_end = Setting(
+        "Control end step", True, "Show control end step ratio"
+    )
+
     history_size: int
     _history_size = Setting(
         "History Size", 1000, "Main memory (RAM) used to keep the history of generated images"

--- a/ai_diffusion/ui/model.py
+++ b/ai_diffusion/ui/model.py
@@ -311,7 +311,7 @@ class Model(QObject):
         image = self._doc.get_layer_image(layer, bounds)
         if control.mode.is_lines:
             image.make_opaque(background=Qt.GlobalColor.white)
-        return Control(control.mode, image, control.strength)
+        return Control(control.mode, image, strength=control.strength, end=control.end)
 
     def generate_control_layer(self, control: Control):
         ok, msg = self._doc.check_color_mode()

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -913,6 +913,7 @@ class InterfaceSettings(SettingsTab):
         S = Settings
         self.add("prompt_line_count", SpinBoxSetting(S._prompt_line_count, self, 1, 10))
         self.add("show_negative_prompt", CheckBoxSetting(S._show_negative_prompt, "Show", self))
+        self.add("show_control_end", CheckBoxSetting(S._show_control_end, "Show", self))
 
         self._layout.addStretch()
 

--- a/ai_diffusion/ui/widget.py
+++ b/ai_diffusion/ui/widget.py
@@ -139,7 +139,7 @@ class ControlWidget(QWidget):
         self.end_spin.setValue(1.0)
         self.end_spin.setSuffix("")
         self.end_spin.setSingleStep(0.1)
-        self.end_spin.setToolTip("Control end step ratio")
+        self.end_spin.setToolTip("Control ending step ratio")
         self.end_spin.valueChanged.connect(self._notify)
         self.end_spin.setVisible(settings.show_control_end)
 

--- a/ai_diffusion/ui/widget.py
+++ b/ai_diffusion/ui/widget.py
@@ -141,6 +141,7 @@ class ControlWidget(QWidget):
         self.end_spin.setSingleStep(0.1)
         self.end_spin.setToolTip("Control end step ratio")
         self.end_spin.valueChanged.connect(self._notify)
+        self.end_spin.setVisible(settings.show_control_end)
 
         self.error_text = QLabel(self)
         self.error_text.setText("ControlNet not installed")
@@ -255,7 +256,7 @@ class ControlWidget(QWidget):
         self.add_pose_button.setEnabled(self._is_vector_layer())
         self.strength_spin.setVisible(is_installed)
         self.strength_spin.setEnabled(self._is_first_image_mode())
-        self.end_spin.setVisible(is_installed)
+        self.end_spin.setVisible(is_installed and settings.show_control_end)
         self.end_spin.setEnabled(self._is_first_image_mode())
         self.error_text.setVisible(not is_installed)
         return is_installed
@@ -333,6 +334,12 @@ class ControlListWidget(QWidget):
     def _remove_widget(self, control: ControlWidget):
         self._controls.remove(control)
         control.deleteLater()
+
+    def update_control_field(self, name, function):
+        for control in self._controls:
+            setting = getattr(control, name, None)
+            if setting is not None:
+                function(setting)
 
 
 class ControlLayerButton(QToolButton):
@@ -720,6 +727,9 @@ class GenerationWidget(QWidget):
         elif key == "show_negative_prompt":
             self.negative_textbox.clear()
             self.negative_textbox.setVisible(value)
+        elif key == "show_control_end":
+            self.control_list.update_control_field("end_spin", lambda x: x.setVisible(value))
+            self.control_list.update_control_field("end_spin", lambda x: x.setValue(1.0))
 
     def show_results(self, job: Job):
         if job.kind is JobKind.diffusion:

--- a/ai_diffusion/ui/widget.py
+++ b/ai_diffusion/ui/widget.py
@@ -256,7 +256,7 @@ class ControlWidget(QWidget):
         self.add_pose_button.setEnabled(self._is_vector_layer())
         self.strength_spin.setVisible(is_installed)
         self.strength_spin.setEnabled(self._is_first_image_mode())
-        self.end_spin.setVisible(is_installed and settings.show_control_end)
+        self.end_spin.setVisible(is_installed and settings.show_control_end and mode is not ControlMode.image)
         self.end_spin.setEnabled(self._is_first_image_mode())
         self.error_text.setVisible(not is_installed)
         return is_installed

--- a/ai_diffusion/ui/widget.py
+++ b/ai_diffusion/ui/widget.py
@@ -131,7 +131,16 @@ class ControlWidget(QWidget):
         self.strength_spin.setValue(100)
         self.strength_spin.setSuffix("%")
         self.strength_spin.setSingleStep(10)
+        self.strength_spin.setToolTip("Control strength")
         self.strength_spin.valueChanged.connect(self._notify)
+        
+        self.end_spin = QDoubleSpinBox(self)
+        self.end_spin.setRange(0.0, 1.0)
+        self.end_spin.setValue(1.0)
+        self.end_spin.setSuffix("")
+        self.end_spin.setSingleStep(0.1)
+        self.end_spin.setToolTip("Control end step ratio")
+        self.end_spin.valueChanged.connect(self._notify)
 
         self.error_text = QLabel(self)
         self.error_text.setText("ControlNet not installed")
@@ -152,6 +161,7 @@ class ControlWidget(QWidget):
         layout.addWidget(self.generate_button)
         layout.addWidget(self.add_pose_button)
         layout.addWidget(self.strength_spin)
+        layout.addWidget(self.end_spin)
         layout.addWidget(self.error_text, 1)
         layout.addWidget(self.remove_button)
 
@@ -170,6 +180,7 @@ class ControlWidget(QWidget):
             id = self.layer_select.currentData()
             self._control.image = self._model.document.find_layer(id)  # type: ignore (CTRLLAYER)
             self._control.strength = self.strength_spin.value() / 100
+            self._control.end = self.end_spin.value()
             self.changed.emit()
 
     def update_and_select_layer(self, id: QUuid):
@@ -213,6 +224,7 @@ class ControlWidget(QWidget):
                 self.update_and_select_layer(control.image.uniqueId())  # type: ignore (CTRLLAYER)
                 self.mode_select.setCurrentIndex(self.mode_select.findData(control.mode.value))
                 self.strength_spin.setValue(int(control.strength * 100))
+                self.end_spin.setValue(float(control.end))
             if self._check_is_installed():
                 active_job = self._model.jobs.find(control)
                 has_active_job = active_job and active_job.state is not State.finished
@@ -243,6 +255,8 @@ class ControlWidget(QWidget):
         self.add_pose_button.setEnabled(self._is_vector_layer())
         self.strength_spin.setVisible(is_installed)
         self.strength_spin.setEnabled(self._is_first_image_mode())
+        self.end_spin.setVisible(is_installed)
+        self.end_spin.setEnabled(self._is_first_image_mode())
         self.error_text.setVisible(not is_installed)
         return is_installed
 

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -546,7 +546,8 @@ def create_control_image(image: Image, mode: ControlMode):
             "resolution": image.extent.multiple_of(64).shortest_side,
         }
         if mode is ControlMode.scribble:
-            result = w.add("FakeScribblePreprocessor", 1, **args, safe="enable")
+            result = w.add("PiDiNetPreprocessor", 1, **args, safe="enable")
+            result = w.add("ScribblePreprocessor", 1, image=result, resolution=args['resolution'])
         elif mode is ControlMode.line_art:
             result = w.add("LineArtPreprocessor", 1, **args, coarse="disable")
         elif mode is ControlMode.soft_edge:

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -206,6 +206,7 @@ class Control:
     image: Image | Output
     mask: None | Mask | Output = None
     strength: float = 1.0
+    end: float = 1.0
 
     def __init__(
         self,
@@ -213,11 +214,13 @@ class Control:
         image: Image | Output,
         strength=1.0,
         mask: None | Mask | Output = None,
+        end: float=1.0,
     ):
         self.mode = mode
         self.image = image
         self.strength = strength
         self.mask = mask
+        self.end = end
 
     def load_image(self, w: ComfyWorkflow):
         if isinstance(self.image, Image):
@@ -282,7 +285,7 @@ def apply_conditioning(
         prompt = merge_prompt("", style.style_prompt)
     positive = w.clip_text_encode(clip, prompt)
     negative = w.clip_text_encode(clip, merge_prompt(cond.negative_prompt, style.negative_prompt))
-    model, positive = apply_control(cond, w, comfy, model, positive, style)
+    model, positive, negative = apply_control(cond, w, comfy, model, positive, negative, style)
     if cond.area and cond.prompt != "":
         positive_area = w.clip_text_encode(clip, cond.prompt)
         positive_area = w.conditioning_area(positive_area, cond.area)
@@ -296,6 +299,7 @@ def apply_control(
     comfy: Client,
     model: Output,
     positive: Output,
+    negative: Output,
     style: Style,
 ):
     sd_ver = resolve_sd_version(style, comfy)
@@ -311,7 +315,7 @@ def apply_control(
         if control.mode.is_lines:  # ControlNet expects white lines on black background
             image = w.invert_image(image)
         controlnet = w.load_controlnet(model_file)
-        positive = w.apply_controlnet(positive, controlnet, image, control.strength)
+        positive, negative = w.apply_controlnet(positive, negative, controlnet, image, strength=control.strength, end_percent=control.end)
 
     # Merge all images into a single batch and apply IP-adapter to the model once
     ip_model_file = comfy.ip_adapter_model[sd_ver]
@@ -333,7 +337,7 @@ def apply_control(
                 ip_adapter, clip_vision, ip_image, model, ip_strength, weight_type=weight_type
             )
 
-    return model, positive
+    return model, positive, negative
 
 
 def upscale(

--- a/tests/references/test_create_control_image_scribble.png
+++ b/tests/references/test_create_control_image_scribble.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76a8627fb632e1d65630758be68d2c69a2b2efd04dcf89cf5d69f9b0072aa010
-size 60695
+oid sha256:99b4ea31437981ec57a858647eab7cfb2cf2207192340dbbb155db486525aef0
+size 68029


### PR DESCRIPTION
## Concept

I propose to add a setting field to each control layer to select the ending step ratio. This setting can be combined with strength to achieve better and faster results. Generally speaking, we want the ControlNet to be applied to the first steps to alter the structure of the image, leaving the later steps alone to do the detailing. It even improves performance because in ComfyUI if you set for example the end_step to 0.5, the ControlNet performance impact only occurs on half the steps. 

I also replaced the FakeScribble preprocessor by PiDiNet + Scribble preprocessors, as the results are much more viable as a sketch input to be quickly updated with a simple brush. The SDXL sketch ControlNet can be used for "Scribble" **and** "Lineart" control modes with great results.

(NB : sorry if the two PR are mixed, I was using the scribble control mode as a testing point for ControlNet ending step setting as I am more familiar with it since I set it as default in the SdPaint development. I can rollback this part if needed.)

## Interface

Here is the setting in place : 

![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/ebdc885f-5ec5-48d5-8695-7853a98a44b4)

I also added a configuration setting to hide this field :  

![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/764fbb16-17b9-4d41-beb9-f0f82cd850f4)

I left it to true by default, but of course it could be set to false to keep the interface unchanged.

## Results

Here are some outputs comparison with ControlNet sketch with the original prompt "_A bearded man portrait, comics illustration_", updated prompt "_A bearded viking man portrait, comics illustration_" and seed 42. This method can be applied to all the control methods, personally I generally don't go above 0.7 end step to avoid rendering artifacts.

 - Original picture and detected PiDiNet scribble : 

![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/476047fd-c0ca-4de5-ae32-4cabb502e25e) 
![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/0ff2397f-4aa2-44f8-a29f-0ed57d761d95)

 - Updated picture with control scribble at 100% Strength and 1.0 end step ratio : 
 
You can see that the ControlNet is too strong at the end and produces graphical artifacts on the lines (those are somewhat too sharp).
 
![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/14e6d6ab-2f28-43ec-ade2-dfca462a3118)

 - Updated picture with control scribble at 60% Strength and 1.0 end step ratio : 

As expected the sketch is less followed, but the line art is still too sharp compared to the original picture.

![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/7d55482c-da22-42f7-8134-8c5d0aa6795a)

- **Lastly with the updated code**, 100% Strength and 0.6 end step ratio : 

The sketch is almost perfectly followed, but the final rendering steps produce fewer graphical artifacts.

![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/118914f4-7b3d-4cb3-8263-b666185103b8)


## Performances

Lowering strength does not affect the performance, but the ending step provides a boost to later steps as those are run without ControlNet interference.

 - 100% strength & 1.0 end :  
```
Requested to load SDXL
100%|██████████| 20/20 [00:14<00:00,  1.39it/s]
Prompt executed in 18.01 seconds
```

 - 60% strength & 1.0 end : 
```
Requested to load SDXL
100%|██████████| 20/20 [00:14<00:00,  1.39it/s]
Prompt executed in 17.79 seconds
```

- 100% strength & 0.6 end : 
```
Requested to load SDXL
100%|██████████| 20/20 [00:14<00:00,  1.70it/s]
Prompt executed in 15.18 seconds
```

## Todo
 - [x] Hide ending setting for `ControlMode.image` controls
 - [x] Set interface setting to `false` by default
 - [x] Update control `scribble` test reference picture