### PR TITLE
Performance upgrade by using KSamplerAdvanced

### DIFF
--- a/ai_diffusion/comfyworkflow.py
+++ b/ai_diffusion/comfyworkflow.py
@@ -103,16 +103,10 @@ class ComfyWorkflow:
         sampler="dpmpp_2m_sde_gpu",
         scheduler="normal",
         steps=20,
+        start_at_step=0,
         cfg=7.0,
-        denoise=1.0,
         seed=-1,
-        min_steps=None,
     ):
-        start_at_step = round(steps*(1-denoise))
-        if min_steps and steps - start_at_step < min_steps:
-            start_at_step = math.floor(steps * 1/denoise - steps)
-            steps = start_at_step + min_steps
-
         self.sample_count += steps - start_at_step
 
         return self.add(

--- a/ai_diffusion/comfyworkflow.py
+++ b/ai_diffusion/comfyworkflow.py
@@ -94,6 +94,39 @@ class ComfyWorkflow:
             denoise=denoise,
         )
 
+    def ksampler_advanced(
+        self,
+        model: Output,
+        positive: Output,
+        negative: Output,
+        latent_image: Output,
+        sampler="dpmpp_2m_sde_gpu",
+        scheduler="normal",
+        steps=20,
+        cfg=7.0,
+        denoise=1.0,
+        seed=-1,
+    ):
+        self.sample_count += steps
+
+        return self.add(
+            "KSamplerAdvanced",
+            1,
+            noise_seed=random.getrandbits(64) if seed == -1 else seed,
+            sampler_name=sampler,
+            scheduler=scheduler,
+            model=model,
+            positive=positive,
+            negative=negative,
+            latent_image=latent_image,
+            steps=steps,
+            start_at_step=round(steps*(1-denoise)),
+            end_at_step=steps,
+            cfg=cfg,
+            add_noise='enable',
+            return_with_leftover_noise='disable',
+        )
+
     def model_sampling_discrete(self, model: Output, sampling: str):
         return self.add("ModelSamplingDiscrete", 1, model=model, sampling=sampling, zsnr=False)
 

--- a/ai_diffusion/comfyworkflow.py
+++ b/ai_diffusion/comfyworkflow.py
@@ -108,12 +108,12 @@ class ComfyWorkflow:
         seed=-1,
         min_steps=None,
     ):
-        self.sample_count += steps
-
         start_at_step = round(steps*(1-denoise))
         if min_steps and steps - start_at_step < min_steps:
             start_at_step = math.floor(steps * 1/denoise - steps)
             steps = start_at_step + min_steps
+
+        self.sample_count += steps - start_at_step
 
         return self.add(
             "KSamplerAdvanced",

--- a/ai_diffusion/comfyworkflow.py
+++ b/ai_diffusion/comfyworkflow.py
@@ -112,7 +112,7 @@ class ComfyWorkflow:
 
         start_at_step = round(steps*(1-denoise))
         if min_steps and steps - start_at_step < min_steps:
-            start_at_step = round(steps * 1/denoise - steps)
+            start_at_step = math.floor(steps * 1/denoise - steps)
             steps = start_at_step + min_steps
 
         return self.add(

--- a/ai_diffusion/comfyworkflow.py
+++ b/ai_diffusion/comfyworkflow.py
@@ -106,8 +106,14 @@ class ComfyWorkflow:
         cfg=7.0,
         denoise=1.0,
         seed=-1,
+        min_steps=None,
     ):
         self.sample_count += steps
+
+        start_at_step = round(steps*(1-denoise))
+        if min_steps and steps - start_at_step < min_steps:
+            start_at_step = round(steps * 1/denoise - steps)
+            steps = start_at_step + min_steps
 
         return self.add(
             "KSamplerAdvanced",
@@ -120,7 +126,7 @@ class ComfyWorkflow:
             negative=negative,
             latent_image=latent_image,
             steps=steps,
-            start_at_step=round(steps*(1-denoise)),
+            start_at_step=start_at_step,
             end_at_step=steps,
             cfg=cfg,
             add_noise='enable',

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -110,9 +110,6 @@ class Settings(QObject):
     fixed_seed: bool
     _fixed_seed = Setting("Use Fixed Seed", False, "Fixes the random seed to a specific value")
 
-    use_advanced_sampler: bool
-    _use_advanced_sampler = Setting("Use Advanced Sampler", False, "Use advanced KSampler methods, improves performance by using fewer steps on low strength")
-
     random_seed: str
     _random_seed = Setting(
         "Random Seed", "0", "Random number to produce different results with each generation"

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -100,6 +100,9 @@ class Settings(QObject):
     fixed_seed: bool
     _fixed_seed = Setting("Use Fixed Seed", False, "Fixes the random seed to a specific value")
 
+    use_advanced_sampler: bool
+    _use_advanced_sampler = Setting("Use Advanced Sampler", False, "Use advanced KSampler methods, improves performance by using fewer steps on low strength")
+
     random_seed: str
     _random_seed = Setting(
         "Random Seed", "0", "Random number to produce different results with each generation"

--- a/ai_diffusion/style.py
+++ b/ai_diffusion/style.py
@@ -121,12 +121,6 @@ class StyleSettings:
         "Higher values can produce more refined results but take longer",
     )
 
-    sampler_steps_upscaling = Setting(
-        "Sampler Steps (Upscaling)",
-        15,
-        "Additional sampling steps to run when automatically upscaling images",
-    )
-
     cfg_scale = Setting(
         "Guidance Strength (CFG Scale)",
         7.0,
@@ -156,7 +150,6 @@ class Style:
     vae: str = StyleSettings.vae.default
     sampler: str = StyleSettings.sampler.default
     sampler_steps: int = StyleSettings.sampler_steps.default
-    sampler_steps_upscaling: int = StyleSettings.sampler_steps_upscaling.default
     cfg_scale: float = StyleSettings.cfg_scale.default
     live_sampler: str = StyleSettings.live_sampler.default
     live_sampler_steps: int = StyleSettings.live_sampler_steps.default
@@ -210,7 +203,7 @@ class Style:
         if is_live:
             return SamplerConfig(self.live_sampler, self.live_sampler_steps, self.live_cfg_scale)
         if is_upscaling:
-            return SamplerConfig(self.sampler, self.sampler_steps_upscaling, self.cfg_scale)
+            return SamplerConfig(self.sampler, self.sampler_steps, self.cfg_scale)
         return SamplerConfig(self.sampler, self.sampler_steps, self.cfg_scale)
 
 

--- a/ai_diffusion/style.py
+++ b/ai_diffusion/style.py
@@ -199,11 +199,9 @@ class Style:
     def filename(self):
         return self.filepath.name
 
-    def get_sampler_config(self, is_upscaling=False, is_live=False):
+    def get_sampler_config(self, is_live=False):
         if is_live:
             return SamplerConfig(self.live_sampler, self.live_sampler_steps, self.live_cfg_scale)
-        if is_upscaling:
-            return SamplerConfig(self.sampler, self.sampler_steps, self.cfg_scale)
         return SamplerConfig(self.sampler, self.sampler_steps, self.cfg_scale)
 
 

--- a/ai_diffusion/styles/cinematic-photo-xl.json
+++ b/ai_diffusion/styles/cinematic-photo-xl.json
@@ -9,6 +9,5 @@
     "vae": "Checkpoint Default",
     "sampler": "DPM++ 2M Karras",
     "sampler_steps": 20,
-    "sampler_steps_upscaling": 15,
     "cfg_scale": 6
 }

--- a/ai_diffusion/styles/cinematic-photo.json
+++ b/ai_diffusion/styles/cinematic-photo.json
@@ -8,6 +8,5 @@
     "negative_prompt": "drawing, painting, sketch, bad quality, low resolution, blurry",
     "sampler": "DPM++ 2M Karras",
     "sampler_steps": 20,
-    "sampler_steps_upscaling": 15,
     "cfg_scale": 7
 }

--- a/ai_diffusion/styles/digital-artwork-xl.json
+++ b/ai_diffusion/styles/digital-artwork-xl.json
@@ -9,6 +9,5 @@
     "vae": "Checkpoint Default",
     "sampler": "DPM++ 2M Karras",
     "sampler_steps": 20,
-    "sampler_steps_upscaling": 15,
     "cfg_scale": 7
 }

--- a/ai_diffusion/styles/digital-artwork.json
+++ b/ai_diffusion/styles/digital-artwork.json
@@ -8,6 +8,5 @@
     "negative_prompt": "photo, photorealistic, bad quality, low resolution, blurry",
     "sampler": "DPM++ 2M Karras",
     "sampler_steps": 20,
-    "sampler_steps_upscaling": 15,
     "cfg_scale": 7
 }

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -895,7 +895,6 @@ class DiffusionSettings(SettingsTab):
         self._fixed_seed_checkbox.stateChanged.connect(self.write)
         self._layout.addWidget(self._fixed_seed_checkbox)
 
-        self._use_advanced_sampler_checkbox = QCheckBox("Use advanced samplers", self)
         self.add("use_advanced_sampler", CheckBoxSetting(S._use_advanced_sampler, "Use", self))
 
         self._layout.addStretch()

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -899,8 +899,6 @@ class DiffusionSettings(SettingsTab):
         self._fixed_seed_checkbox.stateChanged.connect(self.write)
         self._layout.addWidget(self._fixed_seed_checkbox)
 
-        self.add("use_advanced_sampler", CheckBoxSetting(S._use_advanced_sampler, "Use", self))
-
         self._layout.addStretch()
 
     def _read(self):

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -738,10 +738,6 @@ class StylePresets(SettingsTab):
         self._default_sampler_widgets = [
             add("sampler", ComboBoxSetting(StyleSettings.sampler, self)),
             add("sampler_steps", SliderSetting(StyleSettings.sampler_steps, self, 1, 100)),
-            add(
-                "sampler_steps_upscaling",
-                SliderSetting(StyleSettings.sampler_steps_upscaling, self, 1, 100),
-            ),
             add("cfg_scale", SliderSetting(StyleSettings.cfg_scale, self, 1.0, 20.0)),
         ]
         self._toggle_default_sampler(False)

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -895,6 +895,9 @@ class DiffusionSettings(SettingsTab):
         self._fixed_seed_checkbox.stateChanged.connect(self.write)
         self._layout.addWidget(self._fixed_seed_checkbox)
 
+        self._use_advanced_sampler_checkbox = QCheckBox("Use advanced samplers", self)
+        self.add("use_advanced_sampler", CheckBoxSetting(S._use_advanced_sampler, "Use", self))
+
         self._layout.addStretch()
 
     def _read(self):

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -173,7 +173,7 @@ def _sampler_params(
         sampler=sampler_name, scheduler=sampler_scheduler, steps=config.steps, start_at_step=0, cfg=config.cfg
     )
     if strength is not None:
-        params["steps"], params["start_at_step"] = _apply_strength(strength=strength, steps=params["steps"], fixed_steps=live.is_active)
+        params["steps"], params["start_at_step"] = _apply_strength(strength=strength, steps=params["steps"], min_steps=config.steps if live.is_active else 1)
     if clip_vision:
         params["cfg"] = min(5, config.cfg)
     if live.is_active:
@@ -187,12 +187,12 @@ def _sampler_params(
     return params
 
 
-def _apply_strength(strength: float, steps: int, fixed_steps: bool = False) -> tuple[int, int]:
+def _apply_strength(strength: float, steps: int, min_steps: int = 0) -> tuple[int, int]:
     start_at_step = round(steps*(1-strength))
 
-    if fixed_steps and start_at_step > 0:
-        start_at_step = math.floor(steps * 1/strength - steps)
-        steps += start_at_step
+    if min_steps and steps - start_at_step < min_steps:
+        steps = math.floor(min_steps * 1/strength)
+        start_at_step = steps - min_steps
 
     return steps, start_at_step
 

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -152,7 +152,7 @@ class LiveParams:
 def _sampler_params(
     style: Style, clip_vision=False, advanced=False, live=LiveParams(), strength=1.0
 ) -> dict[str, Any]:
-    config = style.get_sampler_config(upscale, live.is_active)
+    config = style.get_sampler_config(live.is_active)
     sampler_name = {
         "DDIM": "ddim",
         "DPM++ 2M": "dpmpp_2m",

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -150,7 +150,7 @@ class LiveParams:
 
 
 def _sampler_params(
-    style: Style, clip_vision=False, upscale=False, live=LiveParams(), strength: float = None
+    style: Style, clip_vision=False, advanced=False, live=LiveParams(), strength=1.0
 ) -> dict[str, Any]:
     config = style.get_sampler_config(upscale, live.is_active)
     sampler_name = {
@@ -172,7 +172,7 @@ def _sampler_params(
     params = dict(
         sampler=sampler_name, scheduler=sampler_scheduler, steps=config.steps, cfg=config.cfg
     )
-    if strength is not None and not upscale:
+    if strength < 1.0 and not advanced:
         params["steps"], params["start_at_step"] = _apply_strength(strength=strength, steps=params["steps"], min_steps=config.steps if live.is_active else 1)
     if clip_vision:
         params["cfg"] = min(5, config.cfg)
@@ -656,7 +656,7 @@ def upscale_tiled(
         denoise=strength,
         original_extent=image.extent,
         tile_extent=tile_extent,
-        **_sampler_params(style, upscale=True),
+        **_sampler_params(style, advanced=False),
     )
     if not target_extent.is_multiple_of(8):
         img = w.scale_image(img, target_extent)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -386,7 +386,7 @@ def generate(
     model, clip, vae = load_model_with_lora(w, comfy, style, is_live=live.is_active)
     latent = w.empty_latent_image(extent.initial.width, extent.initial.height, batch)
     model, positive, negative = apply_conditioning(cond, w, comfy, model, clip, style)
-    if settings.use_advanced_sampler:
+    if settings.use_advanced_sampler and not live.is_active:
         out_latent = w.ksampler_advanced(model, positive, negative, latent, **sampler_params)
     else:
         out_latent = w.ksampler(model, positive, negative, latent, **sampler_params)
@@ -501,7 +501,7 @@ def refine(
     if batch > 1 and not live.is_active:
         latent = w.batch_latent(latent, batch)
     model, positive, negative = apply_conditioning(cond, w, comfy, model, clip, style)
-    if settings.use_advanced_sampler:
+    if settings.use_advanced_sampler and not live.is_active:
         sampler = w.ksampler_advanced(model, positive, negative, latent, denoise=strength, **sampler_params)
     else:
         sampler = w.ksampler(model, positive, negative, latent, denoise=strength, **sampler_params)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -150,7 +150,7 @@ class LiveParams:
 
 
 def _sampler_params(
-    style: Style, clip_vision=False, advanced=False, live=LiveParams(), strength=1.0
+    style: Style, clip_vision=False, advanced=True, live=LiveParams(), strength=1.0
 ) -> dict[str, Any]:
     config = style.get_sampler_config(live.is_active)
     sampler_name = {
@@ -172,8 +172,11 @@ def _sampler_params(
     params = dict(
         sampler=sampler_name, scheduler=sampler_scheduler, steps=config.steps, cfg=config.cfg
     )
-    if strength < 1.0 and not advanced:
-        params["steps"], params["start_at_step"] = _apply_strength(strength=strength, steps=params["steps"], min_steps=config.steps if live.is_active else 1)
+    if advanced:
+        if strength < 1.0:
+            params["steps"], params["start_at_step"] = _apply_strength(strength=strength, steps=params["steps"], min_steps=config.steps if live.is_active else 1)
+        else:
+            params["start_at_step"] = 0
     if clip_vision:
         params["cfg"] = min(5, config.cfg)
     if live.is_active:

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -351,7 +351,7 @@ def upscale(
     vae: Output,
     comfy: Client,
 ):
-    params = _sampler_params(style, upscale=True)
+    params = _sampler_params(style, upscale=not settings.use_advanced_sampler)
     if extent.scale > (1 / 1.5):
         # up to 1.5x scale: upscale latent
         upscale = w.scale_latent(latent, extent.expanded)
@@ -364,7 +364,8 @@ def upscale(
         upscale = w.scale_image(upscale, extent.expanded)
         upscale = w.vae_encode(vae, upscale)
         params["denoise"] = 0.4
-        params["steps"] = max(1, int(params["steps"] * 0.8))
+        if not settings.use_advanced_sampler:
+            params["steps"] = max(1, int(params["steps"] * 0.8))
 
     if settings.use_advanced_sampler:
         return w.ksampler_advanced(model, prompt_pos, prompt_neg, upscale, **params)
@@ -435,7 +436,7 @@ def inpaint(comfy: Client, style: Style, image: Image, mask: Mask, cond: Conditi
             model, positive, negative, latent, **_sampler_params(style, clip_vision=True)
         )
     if extent.requires_upscale:
-        params = _sampler_params(style, clip_vision=True, upscale=True)
+        params = _sampler_params(style, clip_vision=True, upscale=not settings.use_advanced_sampler)
         if extent.scale > (1 / 1.5):
             # up to 1.5x scale: upscale latent
             latent = w.scale_latent(out_latent, extent.expanded)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -170,9 +170,9 @@ def _sampler_params(
         "LCM": "sgm_uniform",
     }[config.sampler]
     params = dict(
-        sampler=sampler_name, scheduler=sampler_scheduler, steps=config.steps, start_at_step=0, cfg=config.cfg
+        sampler=sampler_name, scheduler=sampler_scheduler, steps=config.steps, cfg=config.cfg
     )
-    if strength is not None:
+    if strength is not None and not upscale:
         params["steps"], params["start_at_step"] = _apply_strength(strength=strength, steps=params["steps"], min_steps=config.steps if live.is_active else 1)
     if clip_vision:
         params["cfg"] = min(5, config.cfg)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -386,8 +386,14 @@ def generate(
     model, clip, vae = load_model_with_lora(w, comfy, style, is_live=live.is_active)
     latent = w.empty_latent_image(extent.initial.width, extent.initial.height, batch)
     model, positive, negative = apply_conditioning(cond, w, comfy, model, clip, style)
-    if settings.use_advanced_sampler and not live.is_active:
-        out_latent = w.ksampler_advanced(model, positive, negative, latent, **sampler_params)
+    if settings.use_advanced_sampler:
+        out_latent = w.ksampler_advanced(
+            model, positive,
+            negative,
+            latent,
+            min_steps=sampler_params['steps'] if live.is_active else None,
+            **sampler_params
+        )
     else:
         out_latent = w.ksampler(model, positive, negative, latent, **sampler_params)
     if extent.requires_upscale:
@@ -501,8 +507,16 @@ def refine(
     if batch > 1 and not live.is_active:
         latent = w.batch_latent(latent, batch)
     model, positive, negative = apply_conditioning(cond, w, comfy, model, clip, style)
-    if settings.use_advanced_sampler and not live.is_active:
-        sampler = w.ksampler_advanced(model, positive, negative, latent, denoise=strength, **sampler_params)
+    if settings.use_advanced_sampler:
+        sampler = w.ksampler_advanced(
+            model,
+            positive,
+            negative,
+            latent,
+            denoise=strength,
+            min_steps=sampler_params['steps'] if live.is_active else None,
+            **sampler_params
+        )
     else:
         sampler = w.ksampler(model, positive, negative, latent, denoise=strength, **sampler_params)
     out_image = w.vae_decode(vae, sampler)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -480,7 +480,7 @@ def inpaint(comfy: Client, style: Style, image: Image, mask: Mask, cond: Conditi
         )
         _, positive_up, negative_up = apply_conditioning(cond_upscale, w, comfy, model, clip, style)
         if settings.use_advanced_sampler:
-            out_latent = w.ksampler_advanced(model, positive_up, negative_up, negative, latent, denoise=0.5, **params)
+            out_latent = w.ksampler_advanced(model, positive_up, negative_up, latent, denoise=0.5, **params)
         else:
             out_latent = w.ksampler(model, positive_up, negative_up, latent, denoise=0.5, **params)
 

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -150,7 +150,7 @@ class LiveParams:
 
 
 def _sampler_params(
-    style: Style, clip_vision=False, upscale=False, live=LiveParams()
+    style: Style, clip_vision=False, upscale=False, live=LiveParams(), strength: float = None
 ) -> dict[str, Any]:
     config = style.get_sampler_config(upscale, live.is_active)
     sampler_name = {
@@ -170,8 +170,10 @@ def _sampler_params(
         "LCM": "sgm_uniform",
     }[config.sampler]
     params = dict(
-        sampler=sampler_name, scheduler=sampler_scheduler, steps=config.steps, cfg=config.cfg
+        sampler=sampler_name, scheduler=sampler_scheduler, steps=config.steps, start_at_step=0, cfg=config.cfg
     )
+    if strength is not None:
+        params["steps"], params["start_at_step"] = _apply_strength(strength=strength, steps=params["steps"], fixed_steps=live.is_active)
     if clip_vision:
         params["cfg"] = min(5, config.cfg)
     if live.is_active:
@@ -181,21 +183,18 @@ def _sampler_params(
             params["seed"] = int(settings.random_seed)
         except ValueError:
             log.warning(f"Invalid random seed: {settings.random_seed}")
+
     return params
 
 
-def _apply_strength(strength: float, params: dict, fixed_steps: bool = False) -> dict[str, Any]:
-    steps = params['steps']
+def _apply_strength(strength: float, steps: int, fixed_steps: bool = False) -> tuple[int, int]:
     start_at_step = round(steps*(1-strength))
 
     if fixed_steps and start_at_step > 0:
         start_at_step = math.floor(steps * 1/strength - steps)
         steps += start_at_step
 
-    params['steps'] = steps
-    params['start_at_step'] = start_at_step
-
-    return params
+    return steps, start_at_step
 
 
 def load_model_with_lora(w: ComfyWorkflow, comfy: Client, style: Style, is_live=False):
@@ -384,11 +383,10 @@ def upscale(
     vae: Output,
     comfy: Client,
 ):
-    params = _sampler_params(style)
     if extent.scale > (1 / 1.5):
         # up to 1.5x scale: upscale latent
         upscale = w.scale_latent(latent, extent.expanded)
-        params = _apply_strength(0.5, params)
+        params = _sampler_params(style, strength=0.5)
     else:
         # for larger upscaling factors use super-resolution model
         upscale_model = w.load_upscale_model(comfy.default_upscaler)
@@ -396,7 +394,7 @@ def upscale(
         upscale = w.upscale_image(upscale_model, decoded)
         upscale = w.scale_image(upscale, extent.expanded)
         upscale = w.vae_encode(vae, upscale)
-        params = _apply_strength(0.4, params)
+        params = _sampler_params(style, strength=0.4)
 
     return w.ksampler_advanced(model, prompt_pos, prompt_neg, upscale, **params)
 
@@ -461,8 +459,7 @@ def inpaint(comfy: Client, style: Style, image: Image, mask: Mask, cond: Conditi
         model, positive, negative, latent, **_sampler_params(style, clip_vision=True)
     )
     if extent.requires_upscale:
-        params = _sampler_params(style, clip_vision=True)
-        params = _apply_strength(0.5, params)
+        params = _sampler_params(style, clip_vision=True, strength=0.5)
         if extent.scale > (1 / 1.5):
             # up to 1.5x scale: upscale latent
             latent = w.scale_latent(out_latent, extent.expanded)
@@ -513,8 +510,7 @@ def refine(
 ):
     assert strength > 0 and strength < 1
     extent, image, batch = prepare_image(image, resolve_sd_version(style, comfy), downscale=False)
-    sampler_params = _sampler_params(style, live=live)
-    sampler_params = _apply_strength(strength, sampler_params, fixed_steps=live.is_active)
+    sampler_params = _sampler_params(style, live=live, strength=strength)
 
     w = ComfyWorkflow()
     model, clip, vae = load_model_with_lora(w, comfy, style, is_live=live.is_active)
@@ -547,8 +543,7 @@ def refine_region(
     downscale_if_needed = strength >= 0.7
     sd_ver = resolve_sd_version(style, comfy)
     extent, image, mask_image, batch = prepare_masked(image, mask, sd_ver, downscale_if_needed)
-    sampler_params = _sampler_params(style)
-    sampler_params = _apply_strength(strength, sampler_params)
+    sampler_params = _sampler_params(style, strength=strength)
 
     w = ComfyWorkflow()
     model, clip, vae = load_model_with_lora(w, comfy, style)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,7 +16,7 @@ def make_default_workflow(steps=20):
     positive = w.clip_text_encode(clip, "a photo of a cat")
     negative = w.clip_text_encode(clip, "a photo of a dog")
     latent_image = w.empty_latent_image(512, 512)
-    latent_result = w.ksampler(model, positive, negative, latent_image, steps=steps)
+    latent_result = w.ksampler_advanced(model, positive, negative, latent_image, steps=steps)
     result_image = w.vae_decode(vae, latent_result)
     w.send_image(result_image)
     return w


### PR DESCRIPTION
Replacing `KSampler` by `KSamplerAdvanced` can significantly increase the performance, by using the `add_noise` and `start_at_step` parameters instead of the `denoise` one. The generated images are very similar. 

I'll document the changes in later comments.

 - [x] Use advanced sampler setting
   - Set as new default and remove the setting ?
 - [x] Implement KSamplerAdvanced denoising
 - [x] Skip sampler_steps_upscaling parameter
 - [x] Test rendering
   - [x] Generate
     - [x] LoRA
   - [x] Inpaint
   - [x] Controls
     - [x] IPAdapter
     - [x] OpenPose
     - [x] Sketch
     - [x] Depth
   - [x] ✖ Upscale 
   - [x] ❌ Live
     - [x] Disable for LCM/Live