### PR TITLE
Replace '0.0.0.0' url from ComfyUI with '127.0.0.1'

### DIFF
--- a/ai_diffusion/client.py
+++ b/ai_diffusion/client.py
@@ -397,6 +397,7 @@ class Client:
 
 def parse_url(url: str):
     url = url.strip("/")
+    url = url.replace('0.0.0.0', '127.0.0.1')
     if not url.startswith("http"):
         url = f"http://{url}"
     return url


### PR DESCRIPTION
If ComfyUI is set to run with the --listen parameter, it will log "Listening on 0.0.0.0:PORT" after starting to signify it is not limited to localhost. This breaks the plugin which tries to read the address directly from the log. This patch replaces that special address with the correct url.

Testing instructions:

Add the following line to settings.json.
    "server_arguments": "--listen",


Before the patch, this will cause a failure message "Server running - Connection error."

After the patch is applied the connection will succeed.