### PR TITLE
Support new IPAdapterApply parameters

### DIFF
--- a/ai_diffusion/client.py
+++ b/ai_diffusion/client.py
@@ -126,6 +126,7 @@ class Client:
     clip_vision_model: str
     ip_adapter_model: dict[SDVersion, str | None]
     ip_adapter_has_weight_type = False
+    ip_adapter_has_start = False
     lcm_model: dict[SDVersion, str | None]
     supported_sd_versions: list[SDVersion]
     device_info: DeviceInfo
@@ -166,6 +167,9 @@ class Client:
         }
         client.ip_adapter_has_weight_type = (
             "weight_type" in nodes["IPAdapterApply"]["input"]["required"]
+        )
+        client.ip_adapter_has_start = (
+            "start_at" in nodes["IPAdapterApply"]["input"]["required"]
         )
 
         # Retrieve upscale models

--- a/ai_diffusion/comfyworkflow.py
+++ b/ai_diffusion/comfyworkflow.py
@@ -170,6 +170,7 @@ class ComfyWorkflow:
         model: Output,
         weight: float,
         noise=0.0,
+        end_at=1.0,
         weight_type: str | None = None,
     ):
         args: dict = dict(
@@ -179,6 +180,8 @@ class ComfyWorkflow:
             model=model,
             weight=weight,
             noise=noise,
+            start_at=0.0,
+            end_at=end_at
         )
         if weight_type is not None:
             args["weight_type"] = weight_type

--- a/ai_diffusion/comfyworkflow.py
+++ b/ai_diffusion/comfyworkflow.py
@@ -170,7 +170,7 @@ class ComfyWorkflow:
         model: Output,
         weight: float,
         noise=0.0,
-        end_at=1.0,
+        end_at: float | None = None,
         weight_type: str | None = None,
     ):
         args: dict = dict(
@@ -180,11 +180,12 @@ class ComfyWorkflow:
             model=model,
             weight=weight,
             noise=noise,
-            start_at=0.0,
-            end_at=end_at
         )
         if weight_type is not None:
             args["weight_type"] = weight_type
+        if end_at is not None:
+            args["start_at"] = 0.0
+            args["end_at"] = end_at
         return self.add("IPAdapterApply", 1, **args)
 
     def inpaint_preprocessor(self, image: Output, mask: Output):

--- a/ai_diffusion/ui/widget.py
+++ b/ai_diffusion/ui/widget.py
@@ -258,9 +258,7 @@ class ControlWidget(QWidget):
         self.add_pose_button.setEnabled(self._is_vector_layer())
         self.strength_spin.setVisible(is_installed)
         self.strength_spin.setEnabled(self._is_first_image_mode())
-        self.end_spin.setVisible(
-            is_installed and settings.show_control_end and mode is not ControlMode.image
-        )
+        self.end_spin.setVisible(is_installed and settings.show_control_end)
         self.end_spin.setEnabled(self._is_first_image_mode())
         self.error_text.setVisible(not is_installed)
         return is_installed

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -354,6 +354,8 @@ def apply_control(
             clip_vision = w.load_clip_vision(comfy.clip_vision_model)
             ip_adapter = w.load_ip_adapter(ip_model_file)
             weight_type = "original" if comfy.ip_adapter_has_weight_type else None
+            if not comfy.ip_adapter_has_start:
+                ip_end_at = None
             model = w.apply_ip_adapter(
                 ip_adapter, clip_vision, ip_image, model, ip_strength, end_at=ip_end_at, weight_type=weight_type
             )

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -341,11 +341,13 @@ def apply_control(
     if ip_model_file is not None:
         ip_image = None
         ip_strength = 0
+        ip_end_at = 1.0
         for control in (c for c in cond.control if c.mode is ControlMode.image):
             image = control.load_image(w)
             if ip_image is None:
                 ip_image = image
                 ip_strength = control.strength
+                ip_end_at = control.end
             else:
                 ip_image = w.batch_image(ip_image, image)
         if ip_image is not None:
@@ -353,7 +355,7 @@ def apply_control(
             ip_adapter = w.load_ip_adapter(ip_model_file)
             weight_type = "original" if comfy.ip_adapter_has_weight_type else None
             model = w.apply_ip_adapter(
-                ip_adapter, clip_vision, ip_image, model, ip_strength, weight_type=weight_type
+                ip_adapter, clip_vision, ip_image, model, ip_strength, end_at=ip_end_at, weight_type=weight_type
             )
 
     return model, positive, negative


### PR DESCRIPTION
The `IPAdapterApply` node from https://github.com/cubiq/ComfyUI_IPAdapter_plus has two new parameters : `start_at` default `0.0` and `end_at` default `1.0` .

![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/b9b630f3-a8ae-42de-9445-f9ee7d48150c)

This fixes the `apply_ip_adapter` method by adding a `end_at` parameter, set to `control.end` or default `1.0` .

In the control UI we can also display the "end at" setting available to other control modes, to allow a manual setting.

![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/6b8a8baa-d067-4ee4-91b7-bb507411011c)
