### PR TITLE
Parse LoRA from prompt

### DIFF
--- a/ai_diffusion/attention_edit.py
+++ b/ai_diffusion/attention_edit.py
@@ -3,38 +3,40 @@ from typing import Tuple, List
 
 
 def select_current_parenthesis_block(
-    text: str, cursor_pos: int, open_bracket: str, close_bracket: str
+    text: str, cursor_pos: int, open_brackets: list[str], close_brackets: list[str]
 ) -> Tuple[int, int] | None:
     """Select the current parenthesis block that the cursor points to."""
     # Ensure cursor position is within valid range
     cursor_pos = max(0, min(cursor_pos, len(text)))
 
     # Find the nearest '(' before the cursor
-    start = text.rfind(open_bracket, 0, cursor_pos)
+    start = -1
+    for open_bracket in open_brackets:
+        start = max(start, text.rfind(open_bracket, 0, cursor_pos))
 
     # If '(' is found, find the corresponding ')' after the cursor
     end = -1
     if start != -1:
         open_parens = 1
         for i in range(start + 1, len(text)):
-            if text[i] == open_bracket:
+            if text[i] in open_brackets:
                 open_parens += 1
-            elif text[i] == close_bracket:
+            elif text[i] in close_brackets:
                 open_parens -= 1
                 if open_parens == 0:
                     end = i
                     break
 
     # Return the indices only if both '(' and ')' are found
-    if start != -1 and end > cursor_pos:
-        return (start, end + 1)
+    if start != -1 and end >= cursor_pos:
+        return start, end + 1
     else:
         return None
 
 
 def select_current_word(text: str, cursor_pos: int) -> Tuple[int, int]:
     """Select the word the cursor points to."""
-    delimiters = r".,\/!?%^*;:{}=`~() " + "\t\r\n"
+    delimiters = r".,\/!?%^*;:{}=`~()<> " + "\t\r\n"
     start = end = cursor_pos
 
     # seek backward to find beginning
@@ -50,9 +52,8 @@ def select_current_word(text: str, cursor_pos: int) -> Tuple[int, int]:
 
 def select_on_cursor_pos(text: str, cursor_pos: int) -> Tuple[int, int]:
     """Return a range in the text based on the cursor_position."""
-    return select_current_parenthesis_block(text, cursor_pos, "(", ")") or select_current_word(
-        text, cursor_pos
-    )
+    return (select_current_parenthesis_block(text, cursor_pos, ["(", "<"], [")", ">"])
+            or select_current_word(text, cursor_pos))
 
 
 class ExprNode:
@@ -77,7 +78,7 @@ def parse_expr(expression: str) -> List[ExprNode]:
     """
 
     def parse_segment(segment):
-        match = re.match(r"^[([{<](.*?):([\d.]+)[\]})>]$", segment)
+        match = re.match(r"^[([{<](.*?):(-?[\d.]+)[\]})>]$", segment)
         if match:
             inner_expr = match.group(1)
             number = float(match.group(2))
@@ -88,7 +89,7 @@ def parse_expr(expression: str) -> List[ExprNode]:
     segments = []
     stack = []
     start = 0
-    bracket_pairs = {"(": ")"}
+    bracket_pairs = {"(": ")", "<": ">"}
 
     for i, char in enumerate(expression):
         if char in bracket_pairs:
@@ -101,7 +102,7 @@ def parse_expr(expression: str) -> List[ExprNode]:
         elif stack and char == stack[-1]:
             stack.pop()
             if not stack:
-                node = parse_segment(expression[start : i + 1])
+                node = parse_segment(expression[start: i + 1])
                 if node.type == "expr":
                     segments.append(node)
                     start = i + 1
@@ -123,10 +124,15 @@ def edit_attention(text: str, positive: bool) -> str:
 
     segments = parse_expr(text)
     if len(segments) == 1 and segments[0].type == "expr":
-        attention_string = text[1 : text.rfind(":")]
+        attention_string = text[1: text.rfind(":")]
         weight = segments[0].weight
         open_bracket = text[0]
         close_bracket = text[-1]
+    elif text[0] == "<":
+        attention_string = text[1:-1]
+        weight = 1.0
+        open_bracket = "<"
+        close_bracket = ">"
     else:
         attention_string = text
         weight = 1.0
@@ -134,11 +140,11 @@ def edit_attention(text: str, positive: bool) -> str:
         close_bracket = ")"
 
     weight = weight + 0.1 * (1 if positive else -1)
-    weight = max(weight, 0.0)
+    weight = max(weight, -2.0)
     weight = min(weight, 2.0)
 
     return (
         attention_string
-        if weight == 1.0
+        if weight == 1.0 and open_bracket == "("
         else f"{open_bracket}{attention_string}:{weight:.1f}{close_bracket}"
     )

--- a/ai_diffusion/attention_edit.py
+++ b/ai_diffusion/attention_edit.py
@@ -52,8 +52,9 @@ def select_current_word(text: str, cursor_pos: int) -> Tuple[int, int]:
 
 def select_on_cursor_pos(text: str, cursor_pos: int) -> Tuple[int, int]:
     """Return a range in the text based on the cursor_position."""
-    return (select_current_parenthesis_block(text, cursor_pos, ["(", "<"], [")", ">"])
-            or select_current_word(text, cursor_pos))
+    return select_current_parenthesis_block(
+        text, cursor_pos, ["(", "<"], [")", ">"]
+    ) or select_current_word(text, cursor_pos)
 
 
 class ExprNode:
@@ -102,7 +103,7 @@ def parse_expr(expression: str) -> List[ExprNode]:
         elif stack and char == stack[-1]:
             stack.pop()
             if not stack:
-                node = parse_segment(expression[start: i + 1])
+                node = parse_segment(expression[start : i + 1])
                 if node.type == "expr":
                     segments.append(node)
                     start = i + 1
@@ -124,7 +125,7 @@ def edit_attention(text: str, positive: bool) -> str:
 
     segments = parse_expr(text)
     if len(segments) == 1 and segments[0].type == "expr":
-        attention_string = text[1: text.rfind(":")]
+        attention_string = text[1 : text.rfind(":")]
         weight = segments[0].weight
         open_bracket = text[0]
         close_bracket = text[-1]

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import math
-import os.path
 import re
+from pathlib import Path
 from typing import Any, List, NamedTuple, Optional
 
 from .image import Bounds, Extent, Image, Mask
@@ -209,8 +209,7 @@ def _parse_loras(client: Client, prompt: str) -> list[dict[str, str | float]]:
         lora_name = ""
 
         for client_lora in client.lora_models:
-            _, lora_filename = os.path.split(client_lora)
-            lora_filename, _ = os.path.splitext(lora_filename)
+            lora_filename = Path(client_lora).stem
             if match[0].lower() == lora_filename.lower():
                 lora_name = client_lora
 

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 import math
+import os.path
+import re
 from typing import Any, List, NamedTuple, Optional
 
 from .image import Bounds, Extent, Image, Mask
@@ -9,6 +11,14 @@ from .resources import ControlMode, SDVersion
 from .settings import settings
 from .comfyworkflow import ComfyWorkflow, Output
 from .util import client_logger as log
+
+
+_pattern_lora = re.compile(r"\s*<lora:([^:<>]+)(?::([^:<>]*))?>\s*", re.IGNORECASE)
+
+
+class LoraException(Exception):
+    def __init__(self, msg):
+        super().__init__(msg)
 
 
 class ScaledExtent(NamedTuple):
@@ -193,6 +203,37 @@ def _sampler_params(
     return params
 
 
+def _parse_loras(client: Client, prompt: str) -> list[dict[str, str | float]]:
+    loras = []
+    for match in _pattern_lora.findall(prompt):
+        lora_name = ""
+
+        for client_lora in client.lora_models:
+            _, lora_filename = os.path.split(client_lora)
+            lora_filename,_ = os.path.splitext(lora_filename)
+            if match[0].lower() == lora_filename.lower():
+                lora_name = client_lora
+
+        if not lora_name:
+            error = f"LoRA not found : {match[0]}"
+            log.warning(error)
+            raise LoraException(error)
+
+        lora_strength = match[1] if match[1] != "" else 1.0
+        try:
+            lora_strength = float(lora_strength)
+        except ValueError:
+            error = f"Invalid LoRA strength for {match[0]} : {lora_strength}"
+            log.warning(error)
+            raise LoraException(error)
+
+        loras.append(dict(
+            name=lora_name,
+            strength=lora_strength
+        ))
+    return loras
+
+
 def _apply_strength(strength: float, steps: int, min_steps: int = 0) -> tuple[int, int]:
     start_at_step = round(steps * (1 - strength))
 
@@ -203,7 +244,7 @@ def _apply_strength(strength: float, steps: int, min_steps: int = 0) -> tuple[in
     return steps, start_at_step
 
 
-def load_model_with_lora(w: ComfyWorkflow, comfy: Client, style: Style, is_live=False):
+def load_model_with_lora(w: ComfyWorkflow, comfy: Client, style: Style, is_live=False, additional_loras: list[dict[str, str | float]] = ()):
     checkpoint = style.sd_checkpoint
     if checkpoint not in comfy.checkpoints:
         checkpoint = next(iter(comfy.checkpoints.keys()))
@@ -220,6 +261,12 @@ def load_model_with_lora(w: ComfyWorkflow, comfy: Client, style: Style, is_live=
     for lora in style.loras:
         if lora["name"] not in comfy.lora_models:
             log.warning(f"Style LoRA {lora['name']} not found, skipping")
+            continue
+        model, clip = w.load_lora(model, clip, lora["name"], lora["strength"], lora["strength"])
+
+    for lora in additional_loras:
+        if lora["name"] not in comfy.lora_models:
+            log.warning(f"Prompt LoRA {lora['name']} not found, skipping")
             continue
         model, clip = w.load_lora(model, clip, lora["name"], lora["strength"], lora["strength"])
 
@@ -312,7 +359,8 @@ def merge_prompt(prompt: str, style_prompt: str):
 def apply_conditioning(
     cond: Conditioning, w: ComfyWorkflow, comfy: Client, model: Output, clip: Output, style: Style
 ):
-    prompt = merge_prompt(cond.prompt, style.style_prompt)
+    prompt = merge_prompt(_pattern_lora.sub("", cond.prompt), style.style_prompt)
+    log.debug(f"prompt: {prompt}")
     if cond.area:
         prompt = merge_prompt("", style.style_prompt)
     positive = w.clip_text_encode(clip, prompt)
@@ -423,7 +471,13 @@ def generate(
     batch = 1 if live.is_active else batch
 
     w = ComfyWorkflow(comfy.nodes_inputs)
-    model, clip, vae = load_model_with_lora(w, comfy, style, is_live=live.is_active)
+    model, clip, vae = load_model_with_lora(
+        w,
+        comfy,
+        style,
+        is_live=live.is_active,
+        additional_loras=_parse_loras(comfy, cond.prompt)
+    )
     latent = w.empty_latent_image(extent.initial.width, extent.initial.height, batch)
     model, positive, negative = apply_conditioning(cond, w, comfy, model, clip, style)
     out_latent = w.ksampler_advanced(model, positive, negative, latent, **sampler_params)
@@ -444,7 +498,7 @@ def inpaint(comfy: Client, style: Style, image: Image, mask: Mask, cond: Conditi
     expanded_bounds = Bounds(*mask.bounds.offset, *region_expanded)
 
     w = ComfyWorkflow(comfy.nodes_inputs)
-    model, clip, vae = load_model_with_lora(w, comfy, style)
+    model, clip, vae = load_model_with_lora(w, comfy, style, additional_loras=_parse_loras(comfy, cond.prompt))
     in_image = w.load_image(scaled_image)
     in_mask = w.load_mask(scaled_mask)
     cropped_mask = w.load_mask(mask.to_image())
@@ -522,7 +576,13 @@ def refine(
     sampler_params = _sampler_params(style, live=live, strength=strength)
 
     w = ComfyWorkflow(comfy.nodes_inputs)
-    model, clip, vae = load_model_with_lora(w, comfy, style, is_live=live.is_active)
+    model, clip, vae = load_model_with_lora(
+        w,
+        comfy,
+        style,
+        is_live=live.is_active,
+        additional_loras=_parse_loras(comfy, cond.prompt)
+    )
     in_image = w.load_image(image)
     if extent.is_incompatible:
         in_image = w.scale_image(in_image, extent.expanded)
@@ -555,7 +615,13 @@ def refine_region(
     sampler_params = _sampler_params(style, strength=strength, live=live)
 
     w = ComfyWorkflow(comfy.nodes_inputs)
-    model, clip, vae = load_model_with_lora(w, comfy, style, is_live=live.is_active)
+    model, clip, vae = load_model_with_lora(
+        w,
+        comfy,
+        style,
+        is_live=live.is_active,
+        additional_loras=_parse_loras(comfy, cond.prompt)
+    )
     in_image = w.load_image(image)
     in_mask = w.load_mask(mask_image)
     if extent.requires_downscale:
@@ -649,7 +715,7 @@ def upscale_tiled(
 
     w = ComfyWorkflow(comfy.nodes_inputs)
     img = w.load_image(image)
-    checkpoint, clip, vae = load_model_with_lora(w, comfy, style)
+    checkpoint, clip, vae = load_model_with_lora(w, comfy, style, additional_loras=_parse_loras(comfy, cond.prompt))
     upscale_model = w.load_upscale_model(model)
     if sd_ver.has_controlnet_blur:
         cond.control.append(Control(ControlMode.blur, img))

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -13,7 +13,7 @@ from .comfyworkflow import ComfyWorkflow, Output
 from .util import client_logger as log
 
 
-_pattern_lora = re.compile(r"\s*<lora:([^:<>]+)(?::([^:<>]*))?>\s*", re.IGNORECASE)
+_pattern_lora = re.compile(r"\s*<lora:([^:<>]+)(?::(-?[^:<>]*))?>\s*", re.IGNORECASE)
 
 
 class LoraException(Exception):
@@ -244,7 +244,7 @@ def _apply_strength(strength: float, steps: int, min_steps: int = 0) -> tuple[in
     return steps, start_at_step
 
 
-def load_model_with_lora(w: ComfyWorkflow, comfy: Client, style: Style, is_live=False, additional_loras: list[dict[str, str | float]] = ()):
+def load_model_with_lora(w: ComfyWorkflow, comfy: Client, style: Style, is_live=False, additional_loras: list[dict[str, str | float]] | tuple = ()):
     checkpoint = style.sd_checkpoint
     if checkpoint not in comfy.checkpoints:
         checkpoint = next(iter(comfy.checkpoints.keys()))

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -360,7 +360,6 @@ def apply_conditioning(
     cond: Conditioning, w: ComfyWorkflow, comfy: Client, model: Output, clip: Output, style: Style
 ):
     prompt = merge_prompt(_pattern_lora.sub("", cond.prompt), style.style_prompt)
-    log.debug(f"prompt: {prompt}")
     if cond.area:
         prompt = merge_prompt("", style.style_prompt)
     positive = w.clip_text_encode(clip, prompt)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -210,7 +210,7 @@ def _parse_loras(client: Client, prompt: str) -> list[dict[str, str | float]]:
 
         for client_lora in client.lora_models:
             _, lora_filename = os.path.split(client_lora)
-            lora_filename,_ = os.path.splitext(lora_filename)
+            lora_filename, _ = os.path.splitext(lora_filename)
             if match[0].lower() == lora_filename.lower():
                 lora_name = client_lora
 
@@ -227,10 +227,7 @@ def _parse_loras(client: Client, prompt: str) -> list[dict[str, str | float]]:
             log.warning(error)
             raise LoraException(error)
 
-        loras.append(dict(
-            name=lora_name,
-            strength=lora_strength
-        ))
+        loras.append(dict(name=lora_name, strength=lora_strength))
     return loras
 
 
@@ -244,7 +241,13 @@ def _apply_strength(strength: float, steps: int, min_steps: int = 0) -> tuple[in
     return steps, start_at_step
 
 
-def load_model_with_lora(w: ComfyWorkflow, comfy: Client, style: Style, is_live=False, additional_loras: list[dict[str, str | float]] | tuple = ()):
+def load_model_with_lora(
+    w: ComfyWorkflow,
+    comfy: Client,
+    style: Style,
+    is_live=False,
+    additional_loras: list[dict[str, str | float]] | tuple = (),
+):
     checkpoint = style.sd_checkpoint
     if checkpoint not in comfy.checkpoints:
         checkpoint = next(iter(comfy.checkpoints.keys()))
@@ -471,11 +474,7 @@ def generate(
 
     w = ComfyWorkflow(comfy.nodes_inputs)
     model, clip, vae = load_model_with_lora(
-        w,
-        comfy,
-        style,
-        is_live=live.is_active,
-        additional_loras=_parse_loras(comfy, cond.prompt)
+        w, comfy, style, is_live=live.is_active, additional_loras=_parse_loras(comfy, cond.prompt)
     )
     latent = w.empty_latent_image(extent.initial.width, extent.initial.height, batch)
     model, positive, negative = apply_conditioning(cond, w, comfy, model, clip, style)
@@ -497,7 +496,9 @@ def inpaint(comfy: Client, style: Style, image: Image, mask: Mask, cond: Conditi
     expanded_bounds = Bounds(*mask.bounds.offset, *region_expanded)
 
     w = ComfyWorkflow(comfy.nodes_inputs)
-    model, clip, vae = load_model_with_lora(w, comfy, style, additional_loras=_parse_loras(comfy, cond.prompt))
+    model, clip, vae = load_model_with_lora(
+        w, comfy, style, additional_loras=_parse_loras(comfy, cond.prompt)
+    )
     in_image = w.load_image(scaled_image)
     in_mask = w.load_mask(scaled_mask)
     cropped_mask = w.load_mask(mask.to_image())
@@ -576,11 +577,7 @@ def refine(
 
     w = ComfyWorkflow(comfy.nodes_inputs)
     model, clip, vae = load_model_with_lora(
-        w,
-        comfy,
-        style,
-        is_live=live.is_active,
-        additional_loras=_parse_loras(comfy, cond.prompt)
+        w, comfy, style, is_live=live.is_active, additional_loras=_parse_loras(comfy, cond.prompt)
     )
     in_image = w.load_image(image)
     if extent.is_incompatible:
@@ -615,11 +612,7 @@ def refine_region(
 
     w = ComfyWorkflow(comfy.nodes_inputs)
     model, clip, vae = load_model_with_lora(
-        w,
-        comfy,
-        style,
-        is_live=live.is_active,
-        additional_loras=_parse_loras(comfy, cond.prompt)
+        w, comfy, style, is_live=live.is_active, additional_loras=_parse_loras(comfy, cond.prompt)
     )
     in_image = w.load_image(image)
     in_mask = w.load_mask(mask_image)
@@ -714,7 +707,9 @@ def upscale_tiled(
 
     w = ComfyWorkflow(comfy.nodes_inputs)
     img = w.load_image(image)
-    checkpoint, clip, vae = load_model_with_lora(w, comfy, style, additional_loras=_parse_loras(comfy, cond.prompt))
+    checkpoint, clip, vae = load_model_with_lora(
+        w, comfy, style, additional_loras=_parse_loras(comfy, cond.prompt)
+    )
     upscale_model = w.load_upscale_model(model)
     if sd_ver.has_controlnet_blur:
         cond.control.append(Control(ControlMode.blur, img))

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -199,12 +199,12 @@ def _sampler_params(
     return params
 
 
-def _parse_loras(client: Client, prompt: str) -> list[dict[str, str | float]]:
+def _parse_loras(client_loras: list[str], prompt: str) -> list[dict[str, str | float]]:
     loras = []
     for match in _pattern_lora.findall(prompt):
         lora_name = ""
 
-        for client_lora in client.lora_models:
+        for client_lora in client_loras:
             lora_filename = Path(client_lora).stem
             if match[0].lower() == lora_filename.lower():
                 lora_name = client_lora
@@ -256,7 +256,7 @@ def load_model_with_lora(
         else:
             log.warning(f"Style VAE {style.vae} not found, using default VAE from checkpoint")
 
-    for lora in chain(style.loras, _parse_loras(comfy, prompt)):
+    for lora in chain(style.loras, _parse_loras(comfy.lora_models, prompt)):
         if lora["name"] not in comfy.lora_models:
             log.warning(f"LoRA {lora['name']} not found, skipping")
             continue

--- a/tests/test_attention_edit.py
+++ b/tests/test_attention_edit.py
@@ -16,8 +16,8 @@ class TestEditAttention:
         assert edit_attention("(bar:1.95)", positive=True) == "(bar:2.0)"
 
     def test_lower_bound(self):
-        assert edit_attention("(bar:0.0)", positive=False) == "(bar:0.0)"
-        assert edit_attention("(bar:0.01)", positive=False) == "(bar:0.0)"
+        assert edit_attention("(bar:-1.95)", positive=False) == "(bar:-2.0)"
+        assert edit_attention("(bar:-2.0)", positive=False) == "(bar:-2.0)"
 
     def test_single_digit(self):
         assert edit_attention("(bar:0)", positive=True) == "(bar:0.1)"
@@ -41,6 +41,12 @@ class TestEditAttention:
     def test_no_weight(self):
         assert edit_attention("(foo)", positive=True) == "((foo):1.1)"
 
+    def test_angle_bracket(self):
+        assert edit_attention("<bar:1.0>", positive=True) == "<bar:1.1>"
+        assert edit_attention("<foo:bar:1.0>", positive=True) == "<foo:bar:1.1>"
+        assert edit_attention("<foo:bar:1.1>", positive=False) == "<foo:bar:1.0>"
+        assert edit_attention("<foo:bar:0.0>", positive=False) == "<foo:bar:-0.1>"
+
 
 class TestSelectOnCursorPos:
     def test_word_selection(self):
@@ -52,3 +58,5 @@ class TestSelectOnCursorPos:
     def test_range_selection(self):
         assert select_on_cursor_pos("(foo:1.3), bar, baz", 1) == (0, 9)
         assert select_on_cursor_pos("foo, (bar:1.1), baz", 6) == (5, 14)
+        assert select_on_cursor_pos("foo, (bar:1.1) <bar:baz:1.0>", 16) == (15, 28)
+

--- a/tests/test_attention_edit.py
+++ b/tests/test_attention_edit.py
@@ -59,4 +59,3 @@ class TestSelectOnCursorPos:
         assert select_on_cursor_pos("(foo:1.3), bar, baz", 1) == (0, 9)
         assert select_on_cursor_pos("foo, (bar:1.1), baz", 6) == (5, 14)
         assert select_on_cursor_pos("foo, (bar:1.1) <bar:baz:1.0>", 16) == (15, 28)
-


### PR DESCRIPTION
This adds the capacity to parse LoRA directly from the prompt, using the Auto1111 webui syntax : `<lora:name:strength>`.

The lora name is searched in all the available lora models in the ComfyUI installation, by case insensitive filename only. No path, no extension, to keep the prompt light.

The strength is optional, replaced by `1.0` if absent.

Once applied the whole `<lora*>` is removed from the prompt before applying the conditioning. 

For example the prompt `photography of a bird <lora:add-detail-xl:1.0>` auto loads the matching LoRA `LoRA\5. SDXL\Style\Add-detail-XL.safetensors` found on my installation : 

![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/fa32a9a6-7e9f-449c-a7f1-c16cf49083cb)

If the LoRA is not found in the available models, an error is returned :  

![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/3fa9b026-75e0-4e4c-8326-d38432d4ab7b)

Same concept if an invalid strength is given : 

![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/3c1c9dd8-c892-4490-9313-6fc8d1513682)

I find it more responsive to display the error directly in the krita interface, but it could be replaced by a log line only in `client.log` 
