### PR TITLE
Free lunch for Krita AI Diffusion - Implement FreeU

### DIFF
--- a/ai_diffusion/comfyworkflow.py
+++ b/ai_diffusion/comfyworkflow.py
@@ -249,6 +249,17 @@ class ComfyWorkflow:
 
         return self.add("IPAdapterApply", 1, **args)
 
+    def apply_freeu(self, model: Output, b1: float, b2: float, s1: float, s2: float):
+        return self.add(
+            "FreeU_V2",
+            1,
+            model=model,
+            b1=b1,
+            b2=b2,
+            s1=s1,
+            s2=s2,
+        )
+
     def inpaint_preprocessor(self, image: Output, mask: Output):
         return self.add("InpaintPreprocessor", 1, image=image, mask=mask)
 

--- a/ai_diffusion/style.py
+++ b/ai_diffusion/style.py
@@ -44,7 +44,8 @@ class StyleSettings:
         "Use FreeU",
         False,
         "FreeU is a method of modifying the UNet that can improve model output quality, "
-        "without any additional speed, memory, or computational costs.",
+        "without any additional speed, memory, or computational costs. However the resulting "
+        "images may suffer from oversaturation.",
     )
 
     b1 = Setting(

--- a/ai_diffusion/style.py
+++ b/ai_diffusion/style.py
@@ -40,6 +40,34 @@ class StyleSettings:
         " [ComfyUI]/models/checkpoints.",
     )
 
+    free_u = Setting(
+        "Use FreeU",
+        False,
+        "FreeU is a method of modifying the UNet that can improve model output quality, "
+        "without any additional speed, memory, or computational costs.",
+    )
+
+    b1 = Setting(
+        "b1",
+        1.1,
+        "Backbone factor of the first stage block of decoder.",
+    )
+    b2 = Setting(
+        "b2",
+        1.2,
+        "Backbone factor of the second stage block of decoder.",
+    )
+    s1 = Setting(
+        "s1",
+        0.6,
+        "Skip factor of the first stage block of decoder.",
+    )
+    s2 = Setting(
+        "s2",
+        0.4,
+        "Skip factor of the second stage block of decoder.",
+    )
+
     loras = Setting(
         "LoRA",
         [],
@@ -106,6 +134,11 @@ class Style:
     name: str = StyleSettings.name.default
     sd_version: SDVersion = StyleSettings.sd_version.default
     sd_checkpoint: str = StyleSettings.sd_checkpoint.default
+    free_u: bool = StyleSettings.free_u.default
+    b1: float = StyleSettings.b1.default
+    b2: float = StyleSettings.b2.default
+    s1: float = StyleSettings.s1.default
+    s2: float = StyleSettings.s2.default
     loras: list[dict[str, str | float]]
     style_prompt: str = StyleSettings.style_prompt.default
     negative_prompt: str = StyleSettings.negative_prompt.default

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -20,7 +20,6 @@ from PyQt5.QtWidgets import (
     QScrollArea,
     QSizePolicy,
     QSpinBox,
-    QDoubleSpinBox,
     QStackedWidget,
     QRadioButton,
     QToolButton,
@@ -131,28 +130,6 @@ class SpinBoxSetting(SettingWidget):
     def value(self, v):
         self._spinbox.setValue(v)
 
-
-class DoubleSpinBoxSetting(SettingWidget):
-    def __init__(self, setting: Setting, parent=None, minimum=0, maximum=100, suffix="", single_step=0.10):
-        super().__init__(setting, parent)
-
-        self._double_spinbox = QDoubleSpinBox(self)
-        self._double_spinbox.setMinimumWidth(100)
-        self._double_spinbox.setMinimum(minimum)
-        self._double_spinbox.setMaximum(maximum)
-        self._double_spinbox.setSingleStep(single_step)
-        self._double_spinbox.setSuffix(suffix)
-        self._double_spinbox.setValue(setting.default)
-        self._double_spinbox.valueChanged.connect(self._notify_value_changed)
-        self._layout.addWidget(self._double_spinbox, alignment=Qt.AlignmentFlag.AlignRight)
-
-    @property
-    def value(self):
-        return self._double_spinbox.value()
-
-    @value.setter
-    def value(self, v):
-        self._double_spinbox.setValue(v)
 
 class SliderSetting(SettingWidget):
     _is_float = False
@@ -776,13 +753,6 @@ class StylePresets(SettingsTab):
         self._layout.addWidget(self._checkpoint_warning, alignment=Qt.AlignmentFlag.AlignRight)
 
         add("free_u", CheckBoxSetting(StyleSettings.free_u, "Use FreeU", self))
-        self._style_widgets["free_u"].value_changed.connect(self._toggle_freeu_settings)
-
-        add("b1", DoubleSpinBoxSetting(StyleSettings.b1, self, 0, 5))
-        add("b2", DoubleSpinBoxSetting(StyleSettings.b2, self, 0, 5))
-        add("s1", DoubleSpinBoxSetting(StyleSettings.s1, self, 0, 5))
-        add("s2", DoubleSpinBoxSetting(StyleSettings.s2, self, 0, 5))
-        self._toggle_freeu_settings()
 
         add("loras", LoraList(StyleSettings.loras, self))
         add("style_prompt", LineEditSetting(StyleSettings.style_prompt, self))
@@ -915,14 +885,6 @@ class StylePresets(SettingsTab):
     def _toggle_live_sampler(self, checked: bool):
         for widget in self._live_sampler_widgets:
             widget.visible = checked
-
-    def _toggle_freeu_settings(self):
-        # Toggle visibility based on the checkbox state
-        checked = self._style_widgets["free_u"].value
-        self._style_widgets["b1"].setVisible(checked)
-        self._style_widgets["b2"].setVisible(checked)
-        self._style_widgets["s1"].setVisible(checked)
-        self._style_widgets["s2"].setVisible(checked)
 
     def _read_style(self, style: Style):
         with self._write_guard:

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -20,6 +20,7 @@ from PyQt5.QtWidgets import (
     QScrollArea,
     QSizePolicy,
     QSpinBox,
+    QDoubleSpinBox,
     QStackedWidget,
     QRadioButton,
     QToolButton,
@@ -130,6 +131,28 @@ class SpinBoxSetting(SettingWidget):
     def value(self, v):
         self._spinbox.setValue(v)
 
+
+class DoubleSpinBoxSetting(SettingWidget):
+    def __init__(self, setting: Setting, parent=None, minimum=0, maximum=100, suffix="", single_step=0.10):
+        super().__init__(setting, parent)
+
+        self._double_spinbox = QDoubleSpinBox(self)
+        self._double_spinbox.setMinimumWidth(100)
+        self._double_spinbox.setMinimum(minimum)
+        self._double_spinbox.setMaximum(maximum)
+        self._double_spinbox.setSingleStep(single_step)
+        self._double_spinbox.setSuffix(suffix)
+        self._double_spinbox.setValue(setting.default)
+        self._double_spinbox.valueChanged.connect(self._notify_value_changed)
+        self._layout.addWidget(self._double_spinbox, alignment=Qt.AlignmentFlag.AlignRight)
+
+    @property
+    def value(self):
+        return self._double_spinbox.value()
+
+    @value.setter
+    def value(self, v):
+        self._double_spinbox.setValue(v)
 
 class SliderSetting(SettingWidget):
     _is_float = False
@@ -752,6 +775,15 @@ class StylePresets(SettingsTab):
         self._checkpoint_warning.setVisible(False)
         self._layout.addWidget(self._checkpoint_warning, alignment=Qt.AlignmentFlag.AlignRight)
 
+        add("free_u", CheckBoxSetting(StyleSettings.free_u, "Use FreeU", self))
+        self._style_widgets["free_u"].value_changed.connect(self._toggle_freeu_settings)
+
+        add("b1", DoubleSpinBoxSetting(StyleSettings.b1, self, 0, 5))
+        add("b2", DoubleSpinBoxSetting(StyleSettings.b2, self, 0, 5))
+        add("s1", DoubleSpinBoxSetting(StyleSettings.s1, self, 0, 5))
+        add("s2", DoubleSpinBoxSetting(StyleSettings.s2, self, 0, 5))
+        self._toggle_freeu_settings()
+
         add("loras", LoraList(StyleSettings.loras, self))
         add("style_prompt", LineEditSetting(StyleSettings.style_prompt, self))
         add("negative_prompt", LineEditSetting(StyleSettings.negative_prompt, self))
@@ -883,6 +915,14 @@ class StylePresets(SettingsTab):
     def _toggle_live_sampler(self, checked: bool):
         for widget in self._live_sampler_widgets:
             widget.visible = checked
+
+    def _toggle_freeu_settings(self):
+        # Toggle visibility based on the checkbox state
+        checked = self._style_widgets["free_u"].value
+        self._style_widgets["b1"].setVisible(checked)
+        self._style_widgets["b2"].setVisible(checked)
+        self._style_widgets["s1"].setVisible(checked)
+        self._style_widgets["s2"].setVisible(checked)
 
     def _read_style(self, style: Style):
         with self._write_guard:

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -211,6 +211,10 @@ def load_model_with_lora(w: ComfyWorkflow, comfy: Client, style: Style, is_live=
     model, clip, vae = w.load_checkpoint(checkpoint)
     clip = w.clip_set_last_layer(clip, (style.clip_skip * -1))
 
+    # Check if FreeU is enabled in the style settings and apply it to the model
+    if style.free_u:
+        model = w.apply_freeu(model, style.b1, style.b2, style.s1, style.s2)
+
     if style.vae != StyleSettings.vae.default:
         if style.vae in comfy.vae_models:
             vae = w.load_vae(style.vae)


### PR DESCRIPTION
I've implemented FreeU functionality into the plugin. It allows for enabling or disabling FreeU with a checkbox in the configuration window. If enabled, the input values are used to to apply the FreeU_V2 node in the workflow builder. If disabled, the input fields for the values are hidden. 

<img width="1143" alt="Screenshot 2023-12-09 201112" src="https://github.com/Acly/krita-ai-diffusion/assets/43049843/fc24eaad-d413-4e81-9ae3-a0e293ecf1b3">

FreeU disabled:
<img width="1689" alt="Screenshot 2023-12-09 201533" src="https://github.com/Acly/krita-ai-diffusion/assets/43049843/02eae3d0-8139-41f0-81c6-f98f59d67b5f">


FreeU enabled:
<img width="1680" alt="Screenshot 2023-12-09 201605" src="https://github.com/Acly/krita-ai-diffusion/assets/43049843/aa4c5d51-7843-4615-b4b3-3ca599f34ac4">
