### PR TITLE
make overflowing Add Lora menus scrollable

### DIFF
--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -299,13 +299,15 @@ class CheckBoxSetting(SettingWidget):
     def value(self, v):
         self._checkbox.setChecked(v)
 
-def _menu_width(menu) -> int:
+
+def _menu_width(menu: QMenu) -> int:
     if not menu.isEmpty():
         last_action = menu.actions()[-1]
         action_rect = menu.actionGeometry(last_action)
         return action_rect.right()
     else:
         return 0
+
 
 class LoraList(QWidget):
     class Item(QWidget):

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -362,8 +362,9 @@ class LoraList(QWidget):
                     menu.addMenu(self._build_menu(v, k, os.path.join(path, k)))
 
             screen = QGuiApplication.screenAt(QCursor.pos())
-            if screen and menu.width() > screen.availableSize().width():
-                menu.setStyleSheet("QMenu{menu-scrollable: 1;}")
+            if screen:
+                if menu.width() > screen.availableSize().width():
+                    menu.setStyleSheet("QMenu{menu-scrollable: 1;}")
                 
             return menu
 

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -361,7 +361,7 @@ class LoraList(QWidget):
                 else:
                     menu.addMenu(self._build_menu(v, k, os.path.join(path, k)))
 
-            if screen := GuiApplication.screenAt(QCursor.pos()):
+            if screen := QGuiApplication.screenAt(QCursor.pos()):
                 if menu.width() > screen.availableSize().width():
                     menu.setStyleSheet("QMenu{menu-scrollable: 1;}")
                 

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -299,7 +299,15 @@ class CheckBoxSetting(SettingWidget):
     def value(self, v):
         self._checkbox.setChecked(v)
 
-
+class QMenu(QMenu):
+    def width(self) -> int:
+        if not self.isEmpty():
+            last_action = self.actions()[-1]
+            action_rect = self.actionGeometry(last_action)
+            return action_rect.right()
+        else:
+            return 0
+            
 class LoraList(QWidget):
     class Item(QWidget):
         changed = pyqtSignal()
@@ -353,6 +361,10 @@ class LoraList(QWidget):
                 else:
                     menu.addMenu(self._build_menu(v, k, os.path.join(path, k)))
 
+            screen = QGuiApplication.screenAt(QCursor.pos())
+            if menu.width() > screen.availableSize().width():
+                menu.setStyleSheet("QMenu{menu-scrollable: 1;}")
+                
             return menu
 
         def _select_update(self, text):

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -361,8 +361,7 @@ class LoraList(QWidget):
                 else:
                     menu.addMenu(self._build_menu(v, k, os.path.join(path, k)))
 
-            screen = QGuiApplication.screenAt(QCursor.pos())
-            if screen:
+            if screen := GuiApplication.screenAt(QCursor.pos()):
                 if menu.width() > screen.availableSize().width():
                     menu.setStyleSheet("QMenu{menu-scrollable: 1;}")
                 

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -362,7 +362,7 @@ class LoraList(QWidget):
                     menu.addMenu(self._build_menu(v, k, os.path.join(path, k)))
 
             screen = QGuiApplication.screenAt(QCursor.pos())
-            if menu.width() > screen.availableSize().width():
+            if screen and menu.width() > screen.availableSize().width():
                 menu.setStyleSheet("QMenu{menu-scrollable: 1;}")
                 
             return menu

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -299,15 +299,14 @@ class CheckBoxSetting(SettingWidget):
     def value(self, v):
         self._checkbox.setChecked(v)
 
-class QMenu(QMenu):
-    def width(self) -> int:
-        if not self.isEmpty():
-            last_action = self.actions()[-1]
-            action_rect = self.actionGeometry(last_action)
-            return action_rect.right()
-        else:
-            return 0
-            
+def _menu_width(menu) -> int:
+    if not menu.isEmpty():
+        last_action = menu.actions()[-1]
+        action_rect = menu.actionGeometry(last_action)
+        return action_rect.right()
+    else:
+        return 0
+
 class LoraList(QWidget):
     class Item(QWidget):
         changed = pyqtSignal()
@@ -362,9 +361,9 @@ class LoraList(QWidget):
                     menu.addMenu(self._build_menu(v, k, os.path.join(path, k)))
 
             if screen := QGuiApplication.screenAt(QCursor.pos()):
-                if menu.width() > screen.availableSize().width():
+                if _menu_width(menu) > screen.availableSize().width():
                     menu.setStyleSheet("QMenu{menu-scrollable: 1;}")
-                
+
             return menu
 
         def _select_update(self, text):


### PR DESCRIPTION
The Add Lora menu with overflow the screen if there are too many items
![problem](https://github.com/Acly/krita-ai-diffusion/assets/98350357/83a33f30-1548-42ef-86d6-d439ac086f92)

This commit makes the menu scrollable if there are too many items.
![fix](https://github.com/Acly/krita-ai-diffusion/assets/98350357/9dbee769-c8f2-4bf9-b3a9-0e6731465f5e)
