### PR TITLE
Add Lora menu drag & drop

### DIFF
--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -401,7 +401,7 @@ class LoraList(QWidget):
                 url = event.mimeData().urls()[0]
                 lora_path = url.toLocalFile()
                 lora_path = lora_path.replace("/", os.sep)
-                
+
                 if client := root.connection.client_if_connected:
                     while os.sep in lora_path:
                         _, lora_path = lora_path.split(os.sep, 1)

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -399,7 +399,7 @@ class LoraList(QWidget):
             if event.mimeData().hasUrls:
                 event.accept()
                 url = event.mimeData().urls()[0]
-                lora_path = url.toLocalFile() # DOCS "returned path will use '/', even if originally created from '\'"
+                lora_path = url.toLocalFile()
                 lora_path = lora_path.replace('/', os.sep)
                 
                 if client := root.connection.client_if_connected:
@@ -411,7 +411,8 @@ class LoraList(QWidget):
 
                 self._select.setText("Error lora not detected by Comfy Server.\n"
                                      "Make sure lora file is is Comfy Server's lora folder.\n"
-                                     "Try refreshing lora list.")
+                                     "Try refreshing lora list."
+                )
 
             else:
                 event.ignore()

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -400,7 +400,7 @@ class LoraList(QWidget):
                 event.accept()
                 url = event.mimeData().urls()[0]
                 lora_path = url.toLocalFile()
-                lora_path = lora_path.replace('/', os.sep)
+                lora_path = lora_path.replace("/", os.sep)
                 
                 if client := root.connection.client_if_connected:
                     while os.sep in lora_path:

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -409,9 +409,10 @@ class LoraList(QWidget):
                             self._select_update(lora_path)
                             return
 
-                self._select.setText("Error lora not detected by Comfy Server.\n"
-                                     "Make sure lora file is is Comfy Server's lora folder.\n"
-                                     "Try refreshing lora list."
+                self._select.setText(
+                    "Error lora not detected by Comfy Server.\n"
+                    "Make sure lora file is is Comfy Server's lora folder.\n"
+                    "Try refreshing lora list."
                 )
 
             else:


### PR DESCRIPTION
This commit enables drag & drop in the add lora menu. This would be a userful feature while search is not available.
![drop](https://github.com/Acly/krita-ai-diffusion/assets/98350357/87065995-b681-4c32-8d51-1852fd840fcc)

This error is displayed if the lora is not in the server's lora list
![error](https://github.com/Acly/krita-ai-diffusion/assets/98350357/764b4d52-38ee-49c8-acf5-201909db29cb)

Because I haven't found a way to get the Comfy Server's Lora folder path I'm splitting the dropped file's path and checking if it matches a relative path in the loralist.
