### PR TITLE
Disable historywidget item dragging

### DIFF
--- a/ai_diffusion/ui/generation.py
+++ b/ai_diffusion/ui/generation.py
@@ -71,6 +71,7 @@ class HistoryWidget(QListWidget):
         self.setIconSize(theme.screen_scale(self, QSize(self._thumb_size, self._thumb_size)))
         self.setFrameStyle(QListWidget.NoFrame)
         self.setStyleSheet(self._list_css)
+        self.setDragEnabled(False)
         self.itemClicked.connect(self.handle_preview_click)
         self.itemDoubleClicked.connect(self.item_activated)
 


### PR DESCRIPTION
Disables the ability to drag history widget items which causes bad results.
![historydrag](https://github.com/Acly/krita-ai-diffusion/assets/98350357/ca44b20c-c4e6-4252-becb-9dc54c3f4f6c)
