### PR TITLE
connect button bug fix

### DIFF
--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -871,7 +871,7 @@ class ConnectionSettings(SettingsTab):
         self.write()
 
     def _connect(self):
-        root.connection.connect()
+        root.connection.connect(settings.server_url)
 
     def update_server_status(self):
         connection = root.connection


### PR DESCRIPTION
When I first started Krita, there were no issues, but when I click the connect button, an error occurs

![스크린샷 2024-03-29 오전 11 59 57](https://github.com/Acly/krita-ai-diffusion/assets/4936005/89d0fae0-2ecf-4a1e-9ead-30d2b59c2184)

![스크린샷 2024-03-29 오전 11 59 17](https://github.com/Acly/krita-ai-diffusion/assets/4936005/8b5d1700-85e7-4705-97d5-62bc83538ced)

client.log

```
2024-03-29 11:56:12,827 INFO Connecting to http://127.0.0.1:8188
2024-03-29 11:56:13,045 INFO Connecting to http://127.0.0.1:8188
2024-03-29 11:56:13,223 INFO Connecting to http://127.0.0.1:8188
2024-03-29 11:56:13,448 INFO Connecting to http://127.0.0.1:8188
2024-03-29 11:56:13,667 INFO Connecting to http://127.0.0.1:8188
```