### PR TITLE
Request for adding sailflow.ai to GPU Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you're looking for a way to easily select objects in the image, there is a [s
 
 You can also rent a GPU instead of running locally. In that case, step 6 is not needed. Instead use the plugin to connect to a remote server.
 
-There is a [step by step guide](https://github.com/Acly/krita-ai-diffusion/wiki/Cloud-GPU) on how to setup cloud GPU on [runpod.io](https://www.runpod.io) or [vast.ai](https://vast.ai).
+There is a [step by step guide](https://github.com/Acly/krita-ai-diffusion/wiki/Cloud-GPU) on how to setup cloud GPU on [runpod.io](https://www.runpod.io) or [vast.ai](https://vast.ai) or [sailflow.ai](https://www.sailflowai.com).
 
 
 ## <a name="screenshots"></a> Screenshots


### PR DESCRIPTION
[feat] add sailflow.ai to GPU Cloud.
Hi, I've tried sailflow.ai, which is other alternative of runpod or vast.ai.
I have placed the link to the setting here: https://github.com/x1y2z3456/krita-ai-diffusion/wiki/Cloud-GPU, hoping it can be included in the wiki, thank you.