### PR TITLE
Add toggle for Self-Attention Guidance ComfyUI node

### DIFF
--- a/ai_diffusion/api.py
+++ b/ai_diffusion/api.py
@@ -57,6 +57,7 @@ class CheckpointInput:
     loras: list[LoraInput] = field(default_factory=list)
     clip_skip: int = 0
     v_prediction_zsnr: bool = False
+    self_attention_guidance: bool = False
 
 
 @dataclass

--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -341,6 +341,9 @@ class ComfyWorkflow:
             end_at=range[1],
         )
 
+    def apply_self_attention_guidance(self, model: Output):
+        return self.add("SelfAttentionGuidance", 1, model=model)
+
     def inpaint_preprocessor(self, image: Output, mask: Output):
         return self.add("InpaintPreprocessor", 1, image=image, mask=mask)
 

--- a/ai_diffusion/style.py
+++ b/ai_diffusion/style.py
@@ -81,6 +81,12 @@ class StyleSettings:
         " noise schedule",
     )
 
+    self_attention_guidance = Setting(
+        "Enable SAG / Self-Attention Guidance",
+        False,
+        'Pay more attention to "difficult" parts of the image. Can improve fine details.',
+    )
+
     preferred_resolution = Setting(
         "Preferred Resolution", 0, "Image resolution the checkpoint was trained on"
     )
@@ -121,6 +127,7 @@ class Style:
     vae: str = StyleSettings.vae.default
     clip_skip: int = StyleSettings.clip_skip.default
     v_prediction_zsnr: bool = StyleSettings.v_prediction_zsnr.default
+    self_attention_guidance: bool = StyleSettings.self_attention_guidance.default
     preferred_resolution: int = StyleSettings.preferred_resolution.default
     sampler: str = StyleSettings.sampler.default
     sampler_steps: int = StyleSettings.sampler_steps.default
@@ -182,6 +189,7 @@ class Style:
             clip_skip=self.clip_skip,
             v_prediction_zsnr=self.v_prediction_zsnr,
             loras=[LoraInput.from_dict(l) for l in self.loras],
+            self_attention_guidance=self.self_attention_guidance,
         )
         return result
 

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -1041,6 +1041,12 @@ class StylePresets(SettingsTab):
         self._checkpoint_advanced_widgets.append(
             add("v_prediction_zsnr", SwitchSetting(StyleSettings.v_prediction_zsnr, parent=self))
         )
+        self._checkpoint_advanced_widgets.append(
+            add(
+                "self_attention_guidance",
+                SwitchSetting(StyleSettings.self_attention_guidance, parent=self),
+            )
+        )
         self._toggle_checkpoint_advanced(False)
 
         add("loras", LoraList(StyleSettings.loras, self))

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -138,6 +138,9 @@ def load_checkpoint_with_lora(w: ComfyWorkflow, checkpoint: CheckpointInput, mod
     elif is_lcm:
         model = w.model_sampling_discrete(model, "lcm")
 
+    if checkpoint.self_attention_guidance:
+        model = w.apply_self_attention_guidance(model)
+
     return model, clip, vae
 
 


### PR DESCRIPTION
Not convinced this is an unalloyed good in tests. Seems to result in sharper images when generating de-novo. Details aren't always better though. As I understand SAG, it just makes the schedule spend more time in areas that SD attends to more strongly. I think it depends on how good a grasp the model has on the situation it's generating, whether this leads to good outcomes.

Pull request is more or less copypasted from https://github.com/Acly/krita-ai-diffusion/pull/208 (thanks!)