### PR TITLE
Allow "Pre-fill" use at 0 strength

### DIFF
--- a/ai_diffusion/api.py
+++ b/ai_diffusion/api.py
@@ -102,6 +102,7 @@ class InpaintMode(Enum):
     remove_object = 4
     replace_background = 5
     custom = 6
+    pre_fill = 7
 
 
 class FillMode(Enum):

--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -440,9 +440,11 @@ class ComfyWorkflow:
     def batch_image(self, batch: Output, image: Output):
         return self.add("ImageBatch", 1, image1=batch, image2=image)
 
-    def inpaint_image(self, model: Output, image: Output, mask: Output):
+    def inpaint_image(self, model: Output, image: Output, mask: Output, seed: int = None):
+        if seed is None:
+            seed = 834729
         return self.add(
-            "INPAINT_InpaintWithModel", 1, inpaint_model=model, image=image, mask=mask, seed=834729
+            "INPAINT_InpaintWithModel", 1, inpaint_model=model, image=image, mask=mask, seed=seed
         )
 
     def crop_mask(self, mask: Output, bounds: Bounds):
@@ -483,6 +485,9 @@ class ComfyWorkflow:
 
     def solid_mask(self, extent: Extent, value=1.0):
         return self.add("SolidMask", 1, width=extent.width, height=extent.height, value=value)
+
+    def grow_mask(self, mask: Output, expand: int):
+        return self.add("GrowMask", 1, mask=mask, expand=expand)
 
     def fill_masked(self, image: Output, mask: Output, mode="neutral", falloff: int = 0):
         return self.add("INPAINT_MaskedFill", 1, image=image, mask=mask, fill=mode, falloff=falloff)

--- a/ai_diffusion/ui/widget.py
+++ b/ai_diffusion/ui/widget.py
@@ -569,7 +569,7 @@ class TextPromptWidget(QWidget):
 class StrengthWidget(QWidget):
     value_changed = pyqtSignal(float)
 
-    def __init__(self, slider_range: tuple[int, int] = (1, 100), parent=None):
+    def __init__(self, slider_range: tuple[int, int] = (0, 100), parent=None):
         super().__init__(parent)
         self._layout = QHBoxLayout()
         self._layout.setContentsMargins(0, 0, 0, 0)
@@ -582,7 +582,7 @@ class StrengthWidget(QWidget):
         self._slider.valueChanged.connect(self.notify_changed)
 
         self._input = QSpinBox(self)
-        self._input.setMinimum(1)
+        self._input.setMinimum(0)
         self._input.setMaximum(100)
         self._input.setSingleStep(5)
         self._input.setPrefix("Strength: ")


### PR DESCRIPTION
Trying to see if the "inpaint with model" method can do a better job than Krita's "Smart Patch Tool".

This code simply allows the strength to be set at 0% (instead of min. 1%). If a region is selected, the generate button now acts as a direct call to ComfyUI `InpaintWithModel` node with `MAT_Places512_G_fp16` as model.
![image](https://github.com/Acly/krita-ai-diffusion/assets/15424198/fa889300-652e-4534-8fd4-621ce6d35dff)

The results are different than the patch tool, but not really better.

I think this PR can safely be ignored, but it was fun nonetheless. 😅 If anyone can find another use for it...