### PR TITLE
Websocket support when server address is https

### DIFF
--- a/ai_diffusion/comfy_client.py
+++ b/ai_diffusion/comfy_client.py
@@ -360,7 +360,10 @@ def parse_url(url: str):
 
 
 def websocket_url(url_http: str):
-    return url_http.replace("http", "ws", 1)
+    if url_http.startswith("https"):
+        return url_http.replace("https", "ws", 1)
+    else:
+        return url_http.replace("http", "ws", 1)
 
 
 def _find_model(


### PR DESCRIPTION
On some cloud services the service address of the tunnel is https://{host}.  In that case we should replace "https" with "ws" to get the correct websocket address.