### PR TITLE
Fix issue 838: Make the Strength spinbox snap to full steps, and show steps.

### DIFF
--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -151,6 +151,11 @@ class Settings(QObject):
         "Auto Preview", True, "Automatically preview the first generated result on the canvas"
     )
 
+    show_steps: bool
+    _show_steps = Setting(
+        "Show Steps", False, "Display the number of steps to be evaluated in the weights box."
+    )
+
     apply_behavior: ApplyBehavior
     _apply_behavior = Setting(
         "Apply Behavior",

--- a/ai_diffusion/style.py
+++ b/ai_diffusion/style.py
@@ -183,6 +183,14 @@ class Style:
         )
         return result
 
+    def get_steps(self, is_live: bool) -> tuple[int, int]:
+        sampler_name = self.live_sampler if is_live else self.sampler
+        preset = SamplerPresets.instance()[sampler_name]
+        max_steps = self.live_sampler_steps if is_live else self.sampler_steps
+        max_steps = max_steps or preset.steps
+        min_steps = min(preset.minimum_steps, max_steps)
+        return min_steps, max_steps
+
 
 def _map_sampler_preset(filepath: str | Path, name: str, steps: int, cfg: float):
     sampler_preset = SamplerPresets.instance().add_missing(name, steps, cfg)

--- a/ai_diffusion/ui/animation.py
+++ b/ai_diffusion/ui/animation.py
@@ -145,6 +145,7 @@ class AnimationWidget(QWidget):
                 self.generate_button.clicked.connect(model.animation.generate),
             ]
             self.queue_button.model = model
+            self.strength_slider.model = model
             self.update_mode()
             self.update_target_layers()
             self.preview_area.clear()

--- a/ai_diffusion/ui/generation.py
+++ b/ai_diffusion/ui/generation.py
@@ -586,6 +586,7 @@ class GenerationWidget(QWidget):
             self.custom_inpaint.model = model
             self.generate_button.model = model
             self.queue_button.model = model
+            self.strength_slider.model = model
             self.history.model_ = model
             self.update_generate_button()
 

--- a/ai_diffusion/ui/live.py
+++ b/ai_diffusion/ui/live.py
@@ -198,6 +198,7 @@ class LiveWidget(QWidget):
             self.apply_layer_button.setEnabled(model.live.has_result)
             self.prompt_widget.region = model.regions
             self.region_widget.root = model.regions
+            self.strength_slider.model = model
             self.update_region()
             self.update_is_active()
             self.update_is_recording()

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -387,6 +387,7 @@ class InterfaceSettings(SettingsTab):
             "show_negative_prompt", SwitchSetting(S._show_negative_prompt, ("Show", "Hide"), self)
         )
         self.add("auto_preview", SwitchSetting(S._auto_preview, parent=self))
+        self.add("show_steps", SwitchSetting(S._show_steps, parent=self))
         self.add("new_seed_after_apply", SwitchSetting(S._new_seed_after_apply, parent=self))
         self.add("debug_dump_workflow", SwitchSetting(S._debug_dump_workflow, parent=self))
 


### PR DESCRIPTION
Fixes https://github.com/Acly/krita-ai-diffusion/issues/838

You can still enter percent, but scroll/inc/dec actions will snap to the next full stepsize. That is, if a style with 20 steps is selected, it will snap to 5, 10, 15... etc. Changing the style does not change the percent (but does change the suffix ofc). Only a deliberate input makes any change to the actual value.
![Screenshot_20240622_005030](https://github.com/Acly/krita-ai-diffusion/assets/540727/3af04c31-357a-49da-821e-c52943cfef3d)

Significant credit to Claude 3.5 Sonnet to pointing me in the right direction. If I just remove a few files (websocket and two more), I can actually feed it the whole remaining Krita AI Diffusion source, basically fill up half its context window, and still only pay 30c per query.