### PR TITLE
Use SamplerCustomAdvanced node to allow new schedulers usage (including AlingYourSteps)

### DIFF
--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -192,11 +192,15 @@ class ComfyWorkflow:
             noise=self.random_noise(seed),
             guider=self.cfg_guider(model, positive, negative, cfg),
             sampler=self.ksampler_select(sampler),
-            sigmas=self.split_sigmas(self.scheduler_sigmas(model, scheduler, steps, model_version), start_at_step)[1],
+            sigmas=self.split_sigmas(
+                self.scheduler_sigmas(model, scheduler, steps, model_version), start_at_step
+            )[1],
             latent_image=latent_image,
         )[1]
 
-    def scheduler_sigmas(self, model: Output, scheduler="normal", steps=20, model_version=SDVersion.sdxl):
+    def scheduler_sigmas(
+        self, model: Output, scheduler="normal", steps=20, model_version=SDVersion.sdxl
+    ):
         if scheduler in ("align_your_steps", "ays"):
             assert model_version in (SDVersion.sd15, SDVersion.sdxl)
 

--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -176,6 +176,7 @@ class ComfyWorkflow:
         positive: Output,
         negative: Output,
         latent_image: Output,
+        model_version: SDVersion,
         sampler="dpmpp_2m_sde_gpu",
         scheduler="normal",
         steps=20,
@@ -191,17 +192,24 @@ class ComfyWorkflow:
             noise=self.random_noise(seed),
             guider=self.cfg_guider(model, positive, negative, cfg),
             sampler=self.ksampler_select(sampler),
-            sigmas=self.split_sigmas(self.scheduler_sigmas(model, scheduler, steps), start_at_step)[1],
+            sigmas=self.split_sigmas(self.scheduler_sigmas(model, scheduler, steps, model_version), start_at_step)[1],
             latent_image=latent_image,
         )[1]
 
-    def scheduler_sigmas(self, model: Output, scheduler="normal", steps=20):
+    def scheduler_sigmas(self, model: Output, scheduler="normal", steps=20, model_version=SDVersion.sdxl):
         if scheduler == "align_your_steps":
+            assert model_version in (SDVersion.sd15, SDVersion.sdxl)
+
+            if model_version == SDVersion.sd15:
+                model_type = "SD1"
+            else:
+                model_type = "SDXL"
+
             return self.add(
                 "AlignYourStepsScheduler",
                 output_count=1,
                 steps=steps,
-                model_type="SDXL",
+                model_type=model_type,
                 denoise=1.0,
             )
         else:

--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -137,7 +137,7 @@ class ComfyWorkflow:
             denoise=denoise,
         )
 
-    def _ksampler_advanced_deprecated(
+    def ksampler_advanced(
         self,
         model: Output,
         positive: Output,
@@ -170,42 +170,6 @@ class ComfyWorkflow:
             return_with_leftover_noise="disable",
         )
 
-    def ksampler_advanced(
-        self,
-        model: Output,
-        positive: Output,
-        negative: Output,
-        latent_image: Output,
-        sampler="dpmpp_2m_sde_gpu",
-        scheduler="normal",
-        steps=20,
-        start_at_step=0,
-        cfg=7.0,
-        seed=-1,
-    ):
-        return self.sampler_custom_advanced(
-            model, positive, negative, latent_image, sampler, scheduler, steps, start_at_step, cfg, seed
-        )
-
-    def scheduler_sigmas(self, model: Output, scheduler: str, steps=20):
-        if scheduler == "align_your_steps":
-            return self.add(
-                "AlignYourStepsScheduler",
-                output_count=1,
-                steps=steps,
-                model_type="SDXL",
-                denoise=1.0,
-            )
-        else:
-            return  self.add(
-                "BasicScheduler",
-                output_count=1,
-                model=model,
-                scheduler=scheduler,
-                steps=steps,
-                denoise=1.0,
-            )
-
     def sampler_custom_advanced(
         self,
         model: Output,
@@ -221,16 +185,45 @@ class ComfyWorkflow:
     ):
         self.sample_count += steps - start_at_step
 
-        sigmas = self.scheduler_sigmas(model, scheduler, steps)
+        return self.add(
+            "SamplerCustomAdvanced",
+            output_count=2,
+            noise=self.random_noise(seed),
+            guider=self.cfg_guider(model, positive, negative, cfg),
+            sampler=self.ksampler_select(sampler),
+            sigmas=self.split_sigmas(self.scheduler_sigmas(model, scheduler, steps), start_at_step)[1],
+            latent_image=latent_image,
+        )[1]
 
-        high_sigmas, low_sigmas = self.add(
+    def scheduler_sigmas(self, model: Output, scheduler="normal", steps=20):
+        if scheduler == "align_your_steps":
+            return self.add(
+                "AlignYourStepsScheduler",
+                output_count=1,
+                steps=steps,
+                model_type="SDXL",
+                denoise=1.0,
+            )
+        else:
+            return self.add(
+                "BasicScheduler",
+                output_count=1,
+                model=model,
+                scheduler=scheduler,
+                steps=steps,
+                denoise=1.0,
+            )
+
+    def split_sigmas(self, sigmas: Output, step=0):
+        return self.add(
             "SplitSigmas",
             output_count=2,
             sigmas=sigmas,
-            step=start_at_step,
+            step=step,
         )
 
-        guider = self.add(
+    def cfg_guider(self, model: Output, positive: Output, negative: Output, cfg=7.0):
+        return self.add(
             "CFGGuider",
             output_count=1,
             model=model,
@@ -239,45 +232,19 @@ class ComfyWorkflow:
             cfg=cfg,
         )
 
-        noise = self.add(
+    def random_noise(self, noise_seed=-1):
+        return self.add(
             "RandomNoise",
             output_count=1,
-            noise_seed=seed,
+            noise_seed=noise_seed,
         )
 
-        ksampler = self.add(
+    def ksampler_select(self, sampler_name="dpmpp_2m_sde_gpu"):
+        return self.add(
             "KSamplerSelect",
             output_count=1,
-            sampler_name=sampler,
+            sampler_name=sampler_name,
         )
-
-        return self.add(
-            "SamplerCustomAdvanced",
-            output_count=1,
-            noise=noise,
-            guider=guider,
-            sampler=ksampler,
-            sigmas=low_sigmas,
-            latent_image=latent_image,
-        )
-
-        # return self.add(
-        #     "KSamplerAdvanced",
-        #     1,
-        #     noise_seed=seed,
-        #     sampler_name=sampler,
-        #     scheduler=scheduler,
-        #     model=model,
-        #     positive=positive,
-        #     negative=negative,
-        #     latent_image=latent_image,
-        #     steps=steps,
-        #     start_at_step=start_at_step,
-        #     end_at_step=steps,
-        #     cfg=cfg,
-        #     add_noise="enable",
-        #     return_with_leftover_noise="disable",
-        # )
 
     def differential_diffusion(self, model: Output):
         return self.add("DifferentialDiffusion", 1, model=model)

--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -191,7 +191,7 @@ class ComfyWorkflow:
             output_count=2,
             noise=self.random_noise(seed),
             guider=self.cfg_guider(model, positive, negative, cfg),
-            sampler=self.ksampler_select(sampler),
+            sampler=self.sampler_select(sampler),
             sigmas=self.split_sigmas(
                 self.scheduler_sigmas(model, scheduler, steps, model_version), start_at_step
             )[1],
@@ -268,12 +268,19 @@ class ComfyWorkflow:
             noise_seed=noise_seed,
         )
 
-    def ksampler_select(self, sampler_name="dpmpp_2m_sde_gpu"):
-        return self.add(
-            "KSamplerSelect",
-            output_count=1,
-            sampler_name=sampler_name,
-        )
+    def sampler_select(self, sampler_name="dpmpp_2m_sde_gpu"):
+        if sampler_name == 'euler_cfgpp':
+            return self.add(
+                "SamplerEulerCFGpp",
+                output_count=1,
+                version="regular",
+            )
+        else:
+            return self.add(
+                "KSamplerSelect",
+                output_count=1,
+                sampler_name=sampler_name,
+            )
 
     def differential_diffusion(self, model: Output):
         return self.add("DifferentialDiffusion", 1, model=model)

--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -269,7 +269,7 @@ class ComfyWorkflow:
         )
 
     def sampler_select(self, sampler_name="dpmpp_2m_sde_gpu"):
-        if sampler_name == 'euler_cfgpp':
+        if sampler_name == "euler_cfgpp":
             return self.add(
                 "SamplerEulerCFGpp",
                 output_count=1,

--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -197,7 +197,7 @@ class ComfyWorkflow:
         )[1]
 
     def scheduler_sigmas(self, model: Output, scheduler="normal", steps=20, model_version=SDVersion.sdxl):
-        if scheduler == "align_your_steps":
+        if scheduler in ("align_your_steps", "ays"):
             assert model_version in (SDVersion.sd15, SDVersion.sdxl)
 
             if model_version == SDVersion.sd15:
@@ -211,6 +211,23 @@ class ComfyWorkflow:
                 steps=steps,
                 model_type=model_type,
                 denoise=1.0,
+            )
+        elif scheduler == "gits":
+            return self.add(
+                "GITSScheduler",
+                output_count=1,
+                steps=steps,
+                coeff=1.2,
+                denoise=1.0,
+            )
+        elif scheduler in ("polyexponential", "poly_exponential"):
+            return self.add(
+                "PolyexponentialScheduler",
+                output_count=1,
+                steps=steps,
+                sigma_max=14.61,
+                sigma_min=0.03,
+                rho=1.0,
             )
         else:
             return self.add(

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -490,7 +490,7 @@ def scale_refine_and_decode(
     positive, negative = apply_control(
         w, prompt_pos, prompt_neg, cond.all_control, extent.desired, models
     )
-    result = w.ksampler_advanced(model, positive, negative, latent, **params)
+    result = w.sampler_custom_advanced(model, positive, negative, latent, **params)
     image = w.vae_decode(vae, result)
     return image
 
@@ -514,7 +514,7 @@ def generate(
     positive, negative = apply_control(
         w, prompt_pos, prompt_neg, cond.all_control, extent.initial, models
     )
-    out_latent = w.ksampler_advanced(model, positive, negative, latent, **_sampler_params(sampling))
+    out_latent = w.sampler_custom_advanced(model, positive, negative, latent, **_sampler_params(sampling))
     out_image = scale_refine_and_decode(
         extent, w, cond, sampling, out_latent, prompt_pos, prompt_neg, model_orig, clip, vae, models
     )
@@ -642,7 +642,7 @@ def inpaint(
         inpaint_model = model
 
     latent = w.batch_latent(latent, batch_count)
-    out_latent = w.ksampler_advanced(
+    out_latent = w.sampler_custom_advanced(
         inpaint_model, positive, negative, latent, **_sampler_params(sampling)
     )
 
@@ -676,7 +676,7 @@ def inpaint(
         positive_up, negative_up = apply_control(
             w, positive_up, negative_up, cond_upscale.all_control, res, models
         )
-        out_latent = w.ksampler_advanced(model, positive_up, negative_up, latent, **sampler_params)
+        out_latent = w.sampler_custom_advanced(model, positive_up, negative_up, latent, **sampler_params)
         out_image = w.vae_decode(vae, out_latent)
         out_image = scale_to_target(upscale_extent, w, out_image, models)
     else:
@@ -721,7 +721,7 @@ def refine(
     positive, negative = apply_control(
         w, positive, negative, cond.all_control, extent.desired, models
     )
-    sampler = w.ksampler_advanced(model, positive, negative, latent, **_sampler_params(sampling))
+    sampler = w.sampler_custom_advanced(model, positive, negative, latent, **_sampler_params(sampling))
     out_image = w.vae_decode(vae, sampler)
     out_image = scale_to_target(extent, w, out_image, models)
     w.send_image(out_image)
@@ -773,7 +773,7 @@ def refine_region(
     if batch_count > 1:
         latent = w.batch_latent(latent, batch_count)
 
-    out_latent = w.ksampler_advanced(
+    out_latent = w.sampler_custom_advanced(
         inpaint_model, positive, negative, latent, **_sampler_params(sampling)
     )
     out_image = scale_refine_and_decode(
@@ -932,7 +932,7 @@ def upscale_tiled(
 
         latent = w.vae_encode(vae, tile_image)
         latent = w.set_latent_noise_mask(latent, tile_mask)
-        sampler = w.ksampler_advanced(
+        sampler = w.sampler_custom_advanced(
             tile_model, tile_pos, tile_neg, latent, **_sampler_params(sampling)
         )
         tile_result = w.vae_decode(vae, sampler)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -514,7 +514,9 @@ def generate(
     positive, negative = apply_control(
         w, prompt_pos, prompt_neg, cond.all_control, extent.initial, models
     )
-    out_latent = w.sampler_custom_advanced(model, positive, negative, latent, models.version, **_sampler_params(sampling))
+    out_latent = w.sampler_custom_advanced(
+        model, positive, negative, latent, models.version, **_sampler_params(sampling)
+    )
     out_image = scale_refine_and_decode(
         extent, w, cond, sampling, out_latent, prompt_pos, prompt_neg, model_orig, clip, vae, models
     )
@@ -676,7 +678,9 @@ def inpaint(
         positive_up, negative_up = apply_control(
             w, positive_up, negative_up, cond_upscale.all_control, res, models
         )
-        out_latent = w.sampler_custom_advanced(model, positive_up, negative_up, latent, models.version, **sampler_params)
+        out_latent = w.sampler_custom_advanced(
+            model, positive_up, negative_up, latent, models.version, **sampler_params
+        )
         out_image = w.vae_decode(vae, out_latent)
         out_image = scale_to_target(upscale_extent, w, out_image, models)
     else:
@@ -721,7 +725,9 @@ def refine(
     positive, negative = apply_control(
         w, positive, negative, cond.all_control, extent.desired, models
     )
-    sampler = w.sampler_custom_advanced(model, positive, negative, latent, models.version, **_sampler_params(sampling))
+    sampler = w.sampler_custom_advanced(
+        model, positive, negative, latent, models.version, **_sampler_params(sampling)
+    )
     out_image = w.vae_decode(vae, sampler)
     out_image = scale_to_target(extent, w, out_image, models)
     w.send_image(out_image)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -490,7 +490,7 @@ def scale_refine_and_decode(
     positive, negative = apply_control(
         w, prompt_pos, prompt_neg, cond.all_control, extent.desired, models
     )
-    result = w.sampler_custom_advanced(model, positive, negative, latent, **params)
+    result = w.sampler_custom_advanced(model, positive, negative, latent, models.version, **params)
     image = w.vae_decode(vae, result)
     return image
 
@@ -514,7 +514,7 @@ def generate(
     positive, negative = apply_control(
         w, prompt_pos, prompt_neg, cond.all_control, extent.initial, models
     )
-    out_latent = w.sampler_custom_advanced(model, positive, negative, latent, **_sampler_params(sampling))
+    out_latent = w.sampler_custom_advanced(model, positive, negative, latent, models.version, **_sampler_params(sampling))
     out_image = scale_refine_and_decode(
         extent, w, cond, sampling, out_latent, prompt_pos, prompt_neg, model_orig, clip, vae, models
     )
@@ -643,7 +643,7 @@ def inpaint(
 
     latent = w.batch_latent(latent, batch_count)
     out_latent = w.sampler_custom_advanced(
-        inpaint_model, positive, negative, latent, **_sampler_params(sampling)
+        inpaint_model, positive, negative, latent, models.version, **_sampler_params(sampling)
     )
 
     if extent.refinement_scaling in [ScaleMode.upscale_small, ScaleMode.upscale_quality]:
@@ -676,7 +676,7 @@ def inpaint(
         positive_up, negative_up = apply_control(
             w, positive_up, negative_up, cond_upscale.all_control, res, models
         )
-        out_latent = w.sampler_custom_advanced(model, positive_up, negative_up, latent, **sampler_params)
+        out_latent = w.sampler_custom_advanced(model, positive_up, negative_up, latent, models.version, **sampler_params)
         out_image = w.vae_decode(vae, out_latent)
         out_image = scale_to_target(upscale_extent, w, out_image, models)
     else:
@@ -721,7 +721,7 @@ def refine(
     positive, negative = apply_control(
         w, positive, negative, cond.all_control, extent.desired, models
     )
-    sampler = w.sampler_custom_advanced(model, positive, negative, latent, **_sampler_params(sampling))
+    sampler = w.sampler_custom_advanced(model, positive, negative, latent, models.version, **_sampler_params(sampling))
     out_image = w.vae_decode(vae, sampler)
     out_image = scale_to_target(extent, w, out_image, models)
     w.send_image(out_image)
@@ -774,7 +774,7 @@ def refine_region(
         latent = w.batch_latent(latent, batch_count)
 
     out_latent = w.sampler_custom_advanced(
-        inpaint_model, positive, negative, latent, **_sampler_params(sampling)
+        inpaint_model, positive, negative, latent, models.version, **_sampler_params(sampling)
     )
     out_image = scale_refine_and_decode(
         extent, w, cond, sampling, out_latent, prompt_pos, prompt_neg, model_orig, clip, vae, models
@@ -933,7 +933,7 @@ def upscale_tiled(
         latent = w.vae_encode(vae, tile_image)
         latent = w.set_latent_noise_mask(latent, tile_mask)
         sampler = w.sampler_custom_advanced(
-            tile_model, tile_pos, tile_neg, latent, **_sampler_params(sampling)
+            tile_model, tile_pos, tile_neg, latent, models.version, **_sampler_params(sampling)
         )
         tile_result = w.vae_decode(vae, sampler)
         out_image = w.merge_image_tile(out_image, tile_layout, i, tile_result)


### PR DESCRIPTION
Here is an update replacing the old `KSamplerAdvanced` by the more recent additions to base ComfyUI : `SamplerCustomAdvanced`, `*Scheduler`, `SplitSigmas`, `RandomNoise`, `CFGGuider`, `KSamplerSelect`.

The functionalities are exactly the same, ie. : `steps`, `start_at_step`, `cfg`, `add_noise`, etc. But it also allow the use of various new scheduler nodes : `BasicScheduler`, `AlignYourStepsScheduler`, `GITSScheduler`, `PolyexponentialScheduler` which are not otherwise available in the schedulers list of the old sampler node.

Coincidentally this allows the usage of the new iPNDM V sampler with Align Your Steps scheduler, which works really well : 

```json
    "iPNDM V": {
        "sampler": "ipndm_v",
        "scheduler": "align_your_steps",
        "steps": 20,
        "cfg": 6.0
    }
```