### PR TITLE
Fix seed assignment for batch requests.

### DIFF
--- a/ai_diffusion/model.py
+++ b/ai_diffusion/model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import asyncio
 from copy import copy
+from dataclasses import replace
 from pathlib import Path
 from enum import Enum
 from typing import Any, NamedTuple
@@ -209,8 +210,10 @@ class Model(QObject, ObservableProperties):
             params.prompt = params.regions[0].prompt
 
         for i in range(count):
-            sampling.seed = sampling.seed + i * settings.batch_size
-            params.seed = sampling.seed
+            input = replace(
+                input, sampling=replace(sampling, seed=sampling.seed + i * settings.batch_size)
+            )
+            params.seed = ensure(input.sampling).seed
             job = self.jobs.add(kind, copy(params))
             await self._enqueue_job(job, input)
 


### PR DESCRIPTION
Batch seeds got broken back in https://github.com/Acly/krita-ai-diffusion/commit/0a2fdb431a741fe8d4d3fe740b28e3e2d3b7d6ac so that all jobs would have the same (last) seed. Basically, because all jobs use the same `input` object, the loop in `enqueue_jobs` overwrites the field, leaving the seed the same value once the job pops. Before the change this wasn't an issue because the code created the workflow immediately, using the seed as it was set in that loop pass.

Easy fix: just clone the `WorkflowInput` before queueing.

(Also this fixes the seed steps being silly.)