### PR TITLE
Downloader: use truststore for system cert trust when available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ requests
 
 # Testing
 aiohttp
+truststore
 python-dotenv
 markdown
 numpy

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -26,6 +26,11 @@ from ai_diffusion import resources
 from ai_diffusion.resources import Arch, ResourceKind
 from ai_diffusion.resources import required_models, default_checkpoints, optional_models
 
+try:
+    import truststore
+    truststore.inject_into_ssl()
+except ImportError:
+    pass
 
 def _progress(name: str, size: int | None):
     return tqdm(


### PR DESCRIPTION
Now with the proxy support, one can easily hit resigning proxies with the model downloader, and naturally `certifi` does not come with support or a way to inject support for arbitrary PKI solutions.

Truststore is an elegant way around this problem, it lets one trust the system certificate store instead of certifi: https://pypi.org/project/truststore/

I find the "just capture all things TLS" pattern the neatest if truststore is installed, but I'm open for debate on the implementation details.

https://truststore.readthedocs.io/en/latest/index.html#using-truststore-with-aiohttp