### PR TITLE
Add a setting to cancel live jobs upon change

### DIFF
--- a/ai_diffusion/comfy_client.py
+++ b/ai_diffusion/comfy_client.py
@@ -301,7 +301,11 @@ class ComfyClient(Client):
                             ClientEvent.progress, self._active.local_id, progress.value
                         )
                     else:
-                        log.error(f"Received message {msg} but there is no active job")
+                        if settings.live_cancel_jobs_on_change:
+                            # likely to be an out-of-order progress from cancelled/interrupted job so don't log these
+                            pass
+                        else:
+                            log.error(f"Received message {msg} but there is no active job")
 
                 if msg["type"] == "executed":
                     job = self._get_active_job(msg["data"]["prompt_id"])

--- a/ai_diffusion/model.py
+++ b/ai_diffusion/model.py
@@ -348,6 +348,8 @@ class Model(QObject, ObservableProperties):
         if input != last_input:
             self.clear_error()
             params = JobParams(bounds, conditioning.positive, regions=job_regions)
+            if settings.live_cancel_jobs_on_change:
+                await self._cancel_everything()
             await self.enqueue_jobs(input, JobKind.live_preview, params)
             return input
 
@@ -362,6 +364,17 @@ class Model(QObject, ObservableProperties):
             if self._layer:  # exclude preview layer
                 exclude.append(self._layer)
         return self._doc.get_image(bounds, exclude_layers=exclude)
+
+    async def _cancel_everything(self):
+        await self._connection.client.clear_queue()
+        await self._connection.client.interrupt()
+        to_remove = [
+            job
+            for job in self.jobs
+            if job.state is JobState.queued or job.state is JobState.executing
+        ]
+        for job in to_remove:
+            self.jobs.remove(job)
 
     def generate_control_layer(self, control: ControlLayer):
         ok, msg = self._doc.check_color_mode()
@@ -811,14 +824,16 @@ class LiveWorkspace(QObject, ObservableProperties):
             if len(job.results) > 0:
                 self.set_result(job.results[0], job.params)
             self.is_active = self._is_active and self._model.document.is_active
-            eventloop.run(_report_errors(self._model, self._continue_generating()))
+            if not settings.live_cancel_jobs_on_change:
+                eventloop.run(_report_errors(self._model, self._continue_generating()))
 
     async def _continue_generating(self):
         while self.is_active and self._model.document.is_active:
             new_input = await self._model._generate_live(self._last_input)
             if new_input is not None:  # frame was scheduled
                 self._last_input = new_input
-                return
+                if not settings.live_cancel_jobs_on_change:
+                    return
             # no changes in input data
             await asyncio.sleep(self._poll_rate)
 

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -150,7 +150,7 @@ class Settings(QObject):
 
     live_cancel_jobs_on_change: bool
     _live_cancel_jobs_on_change = Setting(
-        _("Cancel incomplete jobs on change"),
+        _("Live: Cancel incomplete jobs on change"),
         False,
         _("Prevents intermediate results from being shown in Live Mode"),
     )

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -148,6 +148,13 @@ class Settings(QObject):
         _("NSFW Filter"), 0.0, _("Attempt to filter out images with explicit content")
     )
 
+    live_cancel_jobs_on_change: bool
+    _live_cancel_jobs_on_change = Setting(
+        _("Cancel incomplete jobs on change"),
+        False,
+        _("Prevents intermediate results from being shown in Live Mode"),
+    )
+
     new_seed_after_apply: bool
     _new_seed_after_apply = Setting(
         _("Live: New Seed after Apply"),

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -389,6 +389,10 @@ class DiffusionSettings(SettingsTab):
         self.add("selection_feather", SliderSetting(S._selection_feather, self, 0, 25, "{} %"))
         self.add("selection_padding", SliderSetting(S._selection_padding, self, 0, 25, "{} %"))
         self.add("nsfw_filter", ComboBoxSetting(S._nsfw_filter, parent=self))
+        self.add(
+            "live_cancel_jobs_on_change",
+            SwitchSetting(S._live_cancel_jobs_on_change, parent=self),
+        )
 
         nsfw_settings = [(_("Disabled"), 0.0), (_("Basic"), 0.65), (_("Strict"), 0.8)]
         self._widgets["nsfw_filter"].set_items(nsfw_settings)

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -389,10 +389,6 @@ class DiffusionSettings(SettingsTab):
         self.add("selection_feather", SliderSetting(S._selection_feather, self, 0, 25, "{} %"))
         self.add("selection_padding", SliderSetting(S._selection_padding, self, 0, 25, "{} %"))
         self.add("nsfw_filter", ComboBoxSetting(S._nsfw_filter, parent=self))
-        self.add(
-            "live_cancel_jobs_on_change",
-            SwitchSetting(S._live_cancel_jobs_on_change, parent=self),
-        )
 
         nsfw_settings = [(_("Disabled"), 0.0), (_("Basic"), 0.65), (_("Strict"), 0.8)]
         self._widgets["nsfw_filter"].set_items(nsfw_settings)
@@ -443,6 +439,10 @@ class InterfaceSettings(SettingsTab):
         self.add("auto_preview", SwitchSetting(S._auto_preview, parent=self))
         self.add("show_steps", SwitchSetting(S._show_steps, parent=self))
         self.add("new_seed_after_apply", SwitchSetting(S._new_seed_after_apply, parent=self))
+        self.add(
+            "live_cancel_jobs_on_change",
+            SwitchSetting(S._live_cancel_jobs_on_change, parent=self),
+        )
         self.add("debug_dump_workflow", SwitchSetting(S._debug_dump_workflow, parent=self))
 
         languages = [(lang.name, lang.id) for lang in Localization.available]


### PR DESCRIPTION
Hi, thanks for this amazing plugin!

I've noticed an inconvenience with the way the jobs are scheduled in the live mode, and thought to contribute a fix I implemented for myself.

Current implementation of live mode will try to schedule jobs "sequentially":

- the first change causes a job to be scheduled
- we stop listening for changes until the job is finished
- if the job wasn't for the latest change, a new job is scheduled, etc.

This often results in having to wait for the intermediate results to complete, and is not always convenient. 

This change adds a setting, which, if toggled on, instructs Live mode to clear the queue and interrupt any running jobs upon receiving a new change, thus avoiding having to wait for intermediate results. 