### PR TITLE
Add a grace period between detecting a change and triggering generation in live preview

### DIFF
--- a/ai_diffusion/model.py
+++ b/ai_diffusion/model.py
@@ -5,9 +5,9 @@ from dataclasses import replace
 from pathlib import Path
 from enum import Enum
 import time
-from typing import Any, NamedTuple
+from typing import NamedTuple
 from PyQt5.QtCore import QObject, QUuid, pyqtSignal, Qt
-from PyQt5.QtGui import QImage, QPainter, QColor, QBrush
+from PyQt5.QtGui import QPainter, QColor, QBrush
 import uuid
 
 from . import eventloop, workflow, util
@@ -29,7 +29,7 @@ from .files import FileLibrary
 from .connection import Connection
 from .properties import Property, ObservableProperties
 from .jobs import Job, JobKind, JobParams, JobQueue, JobState, JobRegion
-from .control import ControlLayer, ControlLayerList
+from .control import ControlLayer
 from .region import Region, RegionLink, RootRegion, process_regions, get_region_inpaint_mask
 from .resources import ControlMode
 from .resolution import compute_bounds, compute_relative_bounds

--- a/ai_diffusion/model.py
+++ b/ai_diffusion/model.py
@@ -885,16 +885,17 @@ class LiveWorkspace(QObject, ObservableProperties):
             eventloop.run(_report_errors(self._model, self._continue_generating()))
 
     async def _continue_generating(self):
-        while self.is_active and self._model.document.is_active:
-            new_input, job_params = self._model._prepare_live_workflow()
-            if self._last_input != new_input:
-                now = time.monotonic()
-                if self._last_change + settings.live_redraw_grace_period <= now:
-                    await self._model._generate_live(new_input, job_params)
-                    self._last_input = new_input
-                    return
-            else:
-                self._last_change = time.monotonic()
+        while self.is_active:
+            if self._model.document.is_active:
+                new_input, job_params = self._model._prepare_live_workflow()
+                if self._last_input != new_input:
+                    now = time.monotonic()
+                    if self._last_change + settings.live_redraw_grace_period <= now:
+                        await self._model._generate_live(new_input, job_params)
+                        self._last_input = new_input
+                        return
+                else:
+                    self._last_change = time.monotonic()
             await asyncio.sleep(self._poll_rate)
 
     def apply_result(self, layer_only=False):

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -155,6 +155,13 @@ class Settings(QObject):
         _("Pick a new seed after copying the result to the canvas in Live mode"),
     )
 
+    live_redraw_grace_period: float
+    _live_redraw_grace_period = Setting(
+        _("Live: Redraw grace period"),
+        0.0,
+        _("How long to delay scheduling the live preview job for after a change is made"),
+    )
+
     prompt_translation: str
     _prompt_translation = Setting(
         _("Prompt Translation"),

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -439,6 +439,10 @@ class InterfaceSettings(SettingsTab):
         self.add("auto_preview", SwitchSetting(S._auto_preview, parent=self))
         self.add("show_steps", SwitchSetting(S._show_steps, parent=self))
         self.add("new_seed_after_apply", SwitchSetting(S._new_seed_after_apply, parent=self))
+        self.add(
+            "live_redraw_grace_period",
+            SliderSetting(S._live_redraw_grace_period, self, 0.0, 3.0, "{} s"),
+        )
         self.add("debug_dump_workflow", SwitchSetting(S._debug_dump_workflow, parent=self))
 
         languages = [(lang.name, lang.id) for lang in Localization.available]


### PR DESCRIPTION
As per discussion in #1248 this PR adds logic to delay the live preview generation upon change (without the extensions mentioned in [this comment](https://github.com/Acly/krita-ai-diffusion/pull/1248#issuecomment-2465514392)).
