### PR TITLE
Improve compatibility with custom tag lists

### DIFF
--- a/ai_diffusion/ui/autocomplete.py
+++ b/ai_diffusion/ui/autocomplete.py
@@ -176,11 +176,11 @@ class PromptAutoComplete:
             with tag_path.open("r", encoding="utf-8") as f:
                 csv_reader = csv.reader(f)
                 for tag, type_str, count, _aliases in csv_reader:
-                    if type_str.isdigit(): # skip header rows if they exist
+                    if type_str.isdigit():  # skip header rows if they exist
                         tag = tag.replace("_", " ")
                         try:
                             tag_type = TagType(int(type_str))
-                        except: # default to general category if category is not recognised
+                        except:  # default to general category if category is not recognised
                             tag_type = TagType(0)
                         count = int(count)
                         count_str = str(count)

--- a/ai_diffusion/ui/autocomplete.py
+++ b/ai_diffusion/ui/autocomplete.py
@@ -175,19 +175,21 @@ class PromptAutoComplete:
 
             with tag_path.open("r", encoding="utf-8") as f:
                 csv_reader = csv.reader(f)
-                # skip header line
-                next(csv_reader)
                 for tag, type_str, count, _aliases in csv_reader:
-                    tag = tag.replace("_", " ")
-                    tag_type = TagType(int(type_str))
-                    count = int(count)
-                    count_str = str(count)
-                    if count > 1_000_000:
-                        count_str = f"{count/1_000_000:.0f}m"
-                    elif count > 1_000:
-                        count_str = f"{count/1_000:.0f}k"
-                    meta = f"{tag_name} {count_str}"
-                    all_tags.append(TagItem(tag, tag_type, count, meta))
+                    if type_str.isdigit(): # skip header rows if they exist
+                        tag = tag.replace("_", " ")
+                        try:
+                            tag_type = TagType(int(type_str))
+                        except: # default to general category if category is not recognised
+                            tag_type = TagType(0)
+                        count = int(count)
+                        count_str = str(count)
+                        if count > 1_000_000:
+                            count_str = f"{count/1_000_000:.0f}m"
+                        elif count > 1_000:
+                            count_str = f"{count/1_000:.0f}k"
+                        meta = f"{tag_name} {count_str}"
+                        all_tags.append(TagItem(tag, tag_type, count, meta))
 
         sorted_tags = sorted(all_tags, key=lambda x: x.count, reverse=True)
         seen = set()


### PR DESCRIPTION
This is a simple change which makes the tag list loader a bit more compatible. 

Specifically, it doesn't assume that a header row exists, and will instead skip rows that lack a numeric tag type. Also, to improve compatibility with non-danbooru lists the tag category now defaults to general if the TagType doesn't match the known categories. This change is aimed specifically at e621 which has additional categories when pulling from the api which are not in the danbooru set.

My primary goal was to make my [own tag set](https://github.com/BetaDoggo/danbooru-tag-list/releases/tag/tags) work with the plugin without additional modification.
