### PR TITLE
Only show enabled LoRAs in job info

### DIFF
--- a/ai_diffusion/ui/generation.py
+++ b/ai_diffusion/ui/generation.py
@@ -185,7 +185,13 @@ class HistoryWidget(QListWidget):
             if isinstance(value, list) and len(value) == 0:
                 continue
             if isinstance(value, list) and isinstance(value[0], dict):
-                value = "\n  ".join((f"{v.get('name')} ({v.get('strength')})" for v in value))
+                value = "\n  ".join(
+                    (
+                        f"{v.get('name')} ({v.get('strength')})"
+                        for v in value
+                        if v.get("enabled", True)
+                    )
+                )
             s = f"{self._job_info_translations.get(key, key)}: {value}"
             if tooltip_header:
                 s = wrap_text(s, 80, subsequent_indent=" ")


### PR DESCRIPTION
LoRA list in the job info always included all LoRAs in the style, even if they were disabled for that job.