### PR TITLE
Propagate close event instead of mouse release event in menu widget.

### DIFF
--- a/ai_diffusion/ui/widget.py
+++ b/ai_diffusion/ui/widget.py
@@ -23,6 +23,7 @@ from PyQt5.QtWidgets import (
     QScrollBar,
 )
 from PyQt5.QtGui import (
+    QCloseEvent,
     QDesktopServices,
     QGuiApplication,
     QFontMetrics,
@@ -199,10 +200,10 @@ class QueuePopup(QMenu):
         self.model.resolution_multiplier = value / 10
         self._resolution_multiplier_display.setText(f"{(value / 10):.1f} x")
 
-    def mouseReleaseEvent(self, a0: QMouseEvent | None) -> None:
+    def closeEvent(self, a0: QCloseEvent | None) -> None:
         if parent := cast(QWidget, self.parent()):
             parent.close()
-        return super().mouseReleaseEvent(a0)
+        return super().closeEvent(a0)
 
 
 class QueueButton(QToolButton):


### PR DESCRIPTION
Conjecture from experimenting: When a QSlider is misclicked (on the widget but off the track), the release event is considered by the slider, then propagated to the surrounding widget. Normally the QMenu would not take this as a reason to close, assuming that it probably was just a misaimed click. However, because QMenu was overridden to propagate release events *as close actions*, this mechanism is bypassed. This makes the popup menu extremely fiddly as even a slight miss closes it.

Instead, just propagate the close event directly. This still cleans up the overridden menu, but keeps a slight misclick from closing the dialog.