### PR TITLE
Add xpu to suported table and xpu minor performance increase for bigger canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ insufficient memory!
 <tr><td>AMD GPU</td><td>DirectML (Windows, limited features, 12+ GB VRAM recommended)<br>ROCm (Linux, via custom ComfyUI)</td></tr>
 <tr><td>Apple Silicon</td><td>community support, MPS on macOS 14+</td></tr>
 <tr><td>CPU</td><td>supported, but very slow</td></tr>
-<tr><td>XPU</td><td>supported, may see performance issues (Windows)</td></tr>
+<tr><td>XPU</td><td>supported, may see performance issues (Windows/Linux)</td></tr>
 </table>
 
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ insufficient memory!
 <tr><td>AMD GPU</td><td>DirectML (Windows, limited features, 12+ GB VRAM recommended)<br>ROCm (Linux, via custom ComfyUI)</td></tr>
 <tr><td>Apple Silicon</td><td>community support, MPS on macOS 14+</td></tr>
 <tr><td>CPU</td><td>supported, but very slow</td></tr>
+<tr><td>XPU</td><td>supported, may see performance issues (Windows)</td></tr>
 </table>
 
 

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -682,7 +682,11 @@ def scale_refine_and_decode(
         upscaler = models.upscale[UpscalerName.default]
 
     # if an canvas deviates both sizes from 1024 huge performance penalty tiled vae decreases it this is intel only
-    if extent.desired.width > 1536 or extent.desired.height > 1536 and Server.backend is ServerBackend.xpu:
+    if (
+        extent.desired.width > 1536 
+        or extent.desired.height > 1536 
+        and Server.backend is ServerBackend.xpu
+    ):
         tiled_vae = True
 
     upscale_model = w.load_upscale_model(upscaler)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -683,8 +683,8 @@ def scale_refine_and_decode(
 
     # if an canvas deviates both sizes from 1024 huge performance penalty tiled vae decreases it this is intel only
     if (
-        extent.desired.width > 1536 
-        or extent.desired.height > 1536 
+        extent.desired.width > 1536
+        or extent.desired.height > 1536
         and Server.backend is ServerBackend.xpu
     ):
         tiled_vae = True

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -16,7 +16,6 @@ from .files import FileLibrary, FileFormat
 from .style import Style, StyleSettings, SamplerPresets
 from .resolution import ScaledExtent, ScaleMode, TileLayout, get_inpaint_reference
 from .resources import ControlMode, Arch, UpscalerName, ResourceKind, ResourceId
-from .server import Server
 from .settings import PerformanceSettings, ServerBackend
 from .text import merge_prompt, extract_loras
 from .comfy_workflow import ComfyWorkflow, ComfyRunMode, Input, Output, ComfyNode
@@ -685,7 +684,7 @@ def scale_refine_and_decode(
     if (
         extent.desired.width > 1536
         or extent.desired.height > 1536
-        and Server.backend is ServerBackend.xpu
+        and settings.server_backend is ServerBackend.xpu
     ):
         tiled_vae = True
 

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -682,7 +682,7 @@ def scale_refine_and_decode(
         upscaler = models.upscale[UpscalerName.default]
 
     # if an canvas deviates both sizes from 1024 huge performance penalty tiled vae decreases it this is intel only
-    if extent.desired.width >= 1536 and extent.desired.height >= 1536 and Server.backend is ServerBackend.xpu:
+    if extent.desired.width > 1536 or extent.desired.height > 1536 and Server.backend is ServerBackend.xpu:
         tiled_vae = True
 
     upscale_model = w.load_upscale_model(upscaler)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -16,7 +16,8 @@ from .files import FileLibrary, FileFormat
 from .style import Style, StyleSettings, SamplerPresets
 from .resolution import ScaledExtent, ScaleMode, TileLayout, get_inpaint_reference
 from .resources import ControlMode, Arch, UpscalerName, ResourceKind, ResourceId
-from .settings import PerformanceSettings
+from .server import Server
+from .settings import PerformanceSettings, ServerBackend
 from .text import merge_prompt, extract_loras
 from .comfy_workflow import ComfyWorkflow, ComfyRunMode, Input, Output, ComfyNode
 from .localization import translate as _
@@ -679,6 +680,10 @@ def scale_refine_and_decode(
     else:
         assert mode is ScaleMode.upscale_quality
         upscaler = models.upscale[UpscalerName.default]
+
+    # if an canvas deviates both sizes from 1024 huge performance penalty tiled vae decreases it this is intel only
+    if extent.desired.width >= 1536 and extent.desired.height >= 1536 and Server.backend is ServerBackend.xpu:
+        tiled_vae = True
 
     upscale_model = w.load_upscale_model(upscaler)
     decoded = vae_decode(w, vae, latent, tiled_vae)


### PR DESCRIPTION
Main purpose of this PR:
This PR introduces performance improvements to Krita AI specifically for Intel GPUs.

Performance comparison:

- Before this PR: ~66 seconds for 1920x1080 images

- After this PR: ~34–40 seconds for 1920x1080 images