### PR TITLE
feat: add ctrl-click to cancel queued tasks before generating

### DIFF
--- a/ai_diffusion/ui/generation.py
+++ b/ai_diffusion/ui/generation.py
@@ -761,6 +761,7 @@ class GenerationWidget(QWidget):
                 self.add_region_button.clicked.connect(model.regions.create_region_group),
                 self.region_prompt.activated.connect(model.generate),
                 self.generate_button.clicked.connect(model.generate),
+                self.generate_button.ctrl_clicked.connect(self.generate_replace),
             ]
             self.region_prompt.regions = model.regions
             self.custom_inpaint.model = model
@@ -852,6 +853,11 @@ class GenerationWidget(QWidget):
 
     def toggle_region_only(self, checked: bool):
         self.model.region_only = checked
+
+    def generate_replace(self):
+        """Replace queued jobs with new generation."""
+        self.model.cancel(queued=True)
+        self.model.generate()
 
     def update_generate_button(self):
         if not self.model.has_document:

--- a/ai_diffusion/ui/widget.py
+++ b/ai_diffusion/ui/widget.py
@@ -737,6 +737,8 @@ class WorkspaceSelectWidget(QToolButton):
 
 
 class GenerateButton(QPushButton):
+    ctrl_clicked = pyqtSignal()
+
     def __init__(self, kind: JobKind, parent: QWidget):
         super().__init__(parent)
         self.model = root.active_model
@@ -768,6 +770,17 @@ class GenerateButton(QPushButton):
 
     def leaveEvent(self, a0: QEvent | None):
         self._cost = 0
+
+    def mousePressEvent(self, e: QMouseEvent | None) -> None:
+        if (
+            e is not None
+            and e.button() == Qt.MouseButton.LeftButton
+            and (e.modifiers() & Qt.Modifier.CTRL)
+        ):
+            self.ctrl_clicked.emit()
+            e.accept()
+        else:
+            super().mousePressEvent(e)
 
     def paintEvent(self, a0: QPaintEvent | None) -> None:
         opt = QStyleOption()


### PR DESCRIPTION
I notice myself a lot of times going "Queue->Cancel->Queued, Generate". I usually gen with 4 queued to keep my gpu busy, but often I can tell by the first generation that I did something wrong.

So, now Ctrl-click on the Generate button cancels queued tasks and requeues. (Thanks Sonnet 4!)