### PR TITLE
feat: Switch to enum queue mode, add 'replace' mode.

### DIFF
--- a/ai_diffusion/ui/generation.py
+++ b/ai_diffusion/ui/generation.py
@@ -761,6 +761,7 @@ class GenerationWidget(QWidget):
                 self.add_region_button.clicked.connect(model.regions.create_region_group),
                 self.region_prompt.activated.connect(model.generate),
                 self.generate_button.clicked.connect(model.generate),
+                self.generate_button.ctrl_clicked.connect(model.generate_replace),
             ]
             self.region_prompt.regions = model.regions
             self.custom_inpaint.model = model


### PR DESCRIPTION
Follow up to https://github.com/Acly/krita-ai-diffusion/pull/1879

Kind of janky because of the fact that job queue tasks are split up before the client- I make clear-queue a property of the first job.

Not sure if the enum is in the right place.

Tentatively planning to implement ctrl-click as "Alternate queue mode".