### PR TITLE
Add Prompt as Layer Name Interface Option (Defaulted On)

### DIFF
--- a/ai_diffusion/model.py
+++ b/ai_diffusion/model.py
@@ -599,7 +599,13 @@ class Model(QObject, ObservableProperties):
         if job.kind is JobKind.animation:
             return  # don't show animation preview on canvas (it's slow and clumsy)
 
-        name = f"[{name_prefix}] {trim_text(job.params.name, 77)}"
+        layer_name = ""
+        if settings.prompt_as_layer_name:
+            if job.params.name == "":
+                layer_name = "<no prompt>"
+            else:
+                layer_name = trim_text(job.params.name, 77)
+        name = f"[{name_prefix}] {layer_name} ({job.params.seed})"
         image = job.results[index]
         bounds = job.params.bounds
         if image.extent != bounds.extent:
@@ -631,7 +637,13 @@ class Model(QObject, ObservableProperties):
             if behavior is ApplyBehavior.replace:
                 self.layers.update_layer_image(self.layers.active, image, bounds)
             else:
-                name = f"{prefix}{trim_text(params.name, 200)} ({params.seed})"
+                layer_name = ""
+                if settings.prompt_as_layer_name:
+                    if params.name == "":
+                        layer_name = "<no prompt>"
+                    else:
+                        layer_name = trim_text(params.name, 200)
+                name = f"{prefix}{layer_name} ({params.seed})"
                 pos = self.layers.active if behavior is ApplyBehavior.layer_active else None
                 self.layers.create(name, image, bounds, above=pos)
         else:  # apply to regions
@@ -740,7 +752,13 @@ class Model(QObject, ObservableProperties):
             self.document.import_animation(frames, self.document.playback_time_range[0])
 
         async def _set_layer_name():
-            self.layers.active.name = f"[Animation] {trim_text(job.params.name, 200)}"
+            layer_name = ""
+            if settings.prompt_as_layer_name:
+                if job.params.name == "":
+                    layer_name = "<no prompt>"
+                else:
+                    layer_name = trim_text(job.params.name, 200)
+            self.layers.active.name = f"[Animation] {layer_name}"
 
         eventloop.run(_set_layer_name())
 

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -276,6 +276,13 @@ class Settings(QObject):
         "Apply Region Behavior (Live)", ApplyRegionBehavior.replace
     )
 
+    prompt_as_layer_name: bool
+    _prompt_as_layer_name = Setting(
+        _("Prompt as Layer Name"),
+        True,
+        _("Use the positive prompt as the layer name for the preview layer and new layers"),
+    )
+
     show_builtin_styles: bool
     _show_builtin_styles = Setting(_("Show pre-installed styles"), True)
 

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -483,6 +483,7 @@ class InterfaceSettings(SettingsTab):
             "apply_region_behavior_live",
             ComboBoxSetting(S._apply_region_behavior_live, parent=self),
         )
+        self.add("prompt_as_layer_name", SwitchSetting(S._prompt_as_layer_name, parent=self))
         self.add("new_seed_after_apply", SwitchSetting(S._new_seed_after_apply, parent=self))
         self.add("debug_dump_workflow", SwitchSetting(S._debug_dump_workflow, parent=self))
         self.add("save_image_metadata", SwitchSetting(S._save_image_metadata, parent=self))


### PR DESCRIPTION
I'm not a fan of seeing the beginning of my long prompts in the preview layer and the new layers that are added on apply, as they are usually cut off long before I can see the difference between two layer names/prompts.  I have added an option to turn this off called "Prompt as Layer Name" that is defaulted On to maintain existing behavior.  Setting is described as: "Use the positive prompt as the layer name for the preview layer and new layers."

When turned off, the layer names will be "[Preview] (seed)" or "[Generated] (seed)" without the positive prompt added. This will look identical to how it currently looks when your job has an empty positive prompt.

Other changes:

- Added \<no prompt\> to layer name when the setting is enabled, but the job had no positive prompt.
- Appended seed to the Preview layer name, same as the new applied layer names.