### PR TITLE
Add Options: Save Image Format choice (PNG/WebP/JPEG), Image Quality, Image Name Format

### DIFF
--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -69,11 +69,11 @@ class PerformancePreset(Enum):
 
 
 class ImageFileFormat(Enum):
-    png = ("png", 85)  # fast, large files
-    png_small = ("png", 50)  # slow, smaller files
-    webp = ("webp", 80)
-    webp_lossless = ("webp", 100)
-    jpeg = ("jpeg", 85)
+    png = "PNG (fast)"  # fast, large files
+    png_small = "PNG"  # slow, smaller files
+    webp = "WebP"
+    webp_lossless = "WebP (lossless)"
+    jpeg = "JPEG"
 
     @staticmethod
     def from_extension(filepath: str | Path):
@@ -82,9 +82,33 @@ class ImageFileFormat(Enum):
             return ImageFileFormat.png_small
         if extension == ".webp":
             return ImageFileFormat.webp
-        if extension == ".jpg":
+        if extension == ".jpg" or extension == ".jpeg":
             return ImageFileFormat.jpeg
         raise Exception(f"Unsupported image extension: {extension}")
+
+    @property
+    def extension(self):
+        if self in [ImageFileFormat.png, ImageFileFormat.png_small]:
+            return "png"
+        elif self in [ImageFileFormat.webp, ImageFileFormat.webp_lossless]:
+            return "webp"
+        else:
+            return "jpg"
+
+    @property
+    def quality(self):
+        if self in [ImageFileFormat.png]:
+            return 85
+        elif self in [ImageFileFormat.png_small]:
+            return 50
+        elif self in [ImageFileFormat.webp]:
+            return 80
+        elif self in [ImageFileFormat.webp_lossless]:
+            return 100
+        elif self in [ImageFileFormat.jpeg]:
+            return 85
+        else:
+            return 85
 
     @property
     def no_webp_fallback(self):
@@ -220,6 +244,37 @@ class Settings(QObject):
         _("Save Image Metadata"),
         False,
         _("When saving generated images from thumbnails, include metadata in the PNG"),
+    )
+
+    save_image_format: ImageFileFormat
+    _save_image_format = Setting(
+        _("Save Image Format"),
+        ImageFileFormat.png,
+        _("File format for saved images from thumbnails."),
+    )
+
+    save_image_quality_webp: int
+    _save_image_quality_webp = Setting(
+        _("Save Image Quality (WebP)"),
+        80,
+        _("Quality for WebP encoding (0-100)"),
+    )
+
+    save_image_quality_jpeg: int
+    _save_image_quality_jpeg = Setting(
+        _("Save Image Quality (JPEG)"),
+        85,
+        _("Quality for JPEG encoding (0-100)"),
+    )
+
+    save_image_file_name_format: str
+    _save_image_file_name_format = Setting(
+        _("Save Image File Name Template"),
+        "{document_name}-generated-{job_timestamp}-{job_index}-{prompt}",
+        _(
+            "Template for naming saved images (without extension). Available keys: {keys}.",
+            keys="{document_name}, {job_timestamp}, {current_timestamp}, {job_index}, {prompt}",
+        ),
     )
 
     prompt_line_count: int

--- a/ai_diffusion/ui/settings.py
+++ b/ai_diffusion/ui/settings.py
@@ -26,7 +26,7 @@ from PyQt5.QtGui import QDesktopServices, QGuiApplication, QCursor, QFontMetrics
 from ..client import Client, User, MissingResources
 from ..cloud_client import CloudClient
 from ..resources import Arch, ResourceId
-from ..settings import Settings, ServerMode, PerformancePreset, settings
+from ..settings import Settings, ServerMode, PerformancePreset, settings, ImageFileFormat
 from ..server import Server
 from ..style import Style
 from ..root import root
@@ -484,8 +484,11 @@ class InterfaceSettings(SettingsTab):
             ComboBoxSetting(S._apply_region_behavior_live, parent=self),
         )
         self.add("new_seed_after_apply", SwitchSetting(S._new_seed_after_apply, parent=self))
+        self.add("save_image_format", ComboBoxSetting(S._save_image_format, parent=self))
         self.add("save_image_metadata", SwitchSetting(S._save_image_metadata, parent=self))
         self.add("debug_dump_workflow", SwitchSetting(S._debug_dump_workflow, parent=self))
+
+        self._widgets["save_image_format"].value_changed.connect(self._update_image_format_widgets)
 
         languages = [(lang.name, lang.id) for lang in Localization.available]
         self._widgets["language"].set_items(languages)
@@ -495,6 +498,10 @@ class InterfaceSettings(SettingsTab):
             self._widgets[w].show_label = False
 
         self._layout.addStretch()
+
+    def read(self):
+        super().read()
+        self._update_image_format_widgets()
 
     def _tag_files(self) -> list[str]:
         plugin_tags_path = util.plugin_dir / "tags"
@@ -523,6 +530,12 @@ class InterfaceSettings(SettingsTab):
         translation.enabled = client is not None
         translation.set_items(languages)
         self.read()
+
+    def _update_image_format_widgets(self):
+        fmt = self._widgets["save_image_format"].value
+        self._widgets["save_image_metadata"].setVisible(
+            fmt is ImageFileFormat.png or fmt is ImageFileFormat.png_small
+        )
 
 
 class HistorySizeWidget(QWidget):


### PR DESCRIPTION
I often have to save many images and then run them through batch converters and renaming scripts, so I added some options to remove this step for myself.

New Options:

- Save Image Format (Default PNG (fast)) - Can now choose PNG (fast), PNG, WebP, WebP (Lossless) and JPEG.  This changes which format is used for right click context Save Image in job history thumbnails.
- Save Image Quality WebP (Default 80) - Hidden option only in settings json file.  This will override the default image quality settings in the save function for lossy webp image formats.
- Save Image Quality JPEG (Default 85) - Hidden option only in settings json file.  This will override the default image quality settings in the save function for jpeg image formats.
- Save Image File Name Template - Hidden option only in settings json file.  The default value is the current naming format, but the user can now modify this.  I added {current_timestamp} as another possible key, but there may be more in the future.

Modified:

- Save Image Metadata option is now hidden when neither PNG image save format is chosen.


I had to pass around optional format and quality to the save function and optional quality to the write function.  The save function used the file extension to determine format, but we can now be saving 2 different png and 2 different webp formats.  The write function used the default quality for each format, but the user may modify these qualities for lossy webp and jpeg by editing the settings.json file.

I couldn't easily figure out how to save the ComfyUI workflow metadata to the jpeg and webp formats, so i left this to someone more qualified than myself.  That option remains PNG only, at this time.