### PR TITLE
remove old performance patch xpu

### DIFF
--- a/ai_diffusion/server.py
+++ b/ai_diffusion/server.py
@@ -259,17 +259,12 @@ class Server:
         elif self.backend is ServerBackend.directml:
             torch_args = ["numpy<2", "torch-directml", "torchvision", "torchaudio"]
         elif self.backend is ServerBackend.xpu:
-            torch_args = ["torch==2.6.0", "torchvision==0.21.0", "torchaudio==2.6.0"]
+            torch_args = ["torch==2.8.0", "torchvision==0.23.0", "torchaudio==2.8.0"]
             torch_args += ["--index-url", "https://download.pytorch.org/whl/xpu"]
         await self._pip_install("PyTorch", torch_args, cb)
 
         requirements_txt = Path(__file__).parent / "server_requirements.txt"
         await self._pip_install("ComfyUI", ["-r", str(requirements_txt)], cb)
-
-        if self.backend is ServerBackend.xpu:
-            idx_url = "https://pytorch-extension.intel.com/release-whl/stable/xpu/us/"
-            cmd = ["intel-extension-for-pytorch==2.6.10+xpu", "--extra-index-url", idx_url]
-            await self._pip_install("Ipex", cmd, cb)
 
         requirements_txt = temp_comfy_dir / "requirements.txt"
         await self._pip_install("ComfyUI", ["-r", str(requirements_txt)], cb)

--- a/ai_diffusion/server.py
+++ b/ai_diffusion/server.py
@@ -468,8 +468,6 @@ class Server:
             env = {}
             if self.backend is ServerBackend.cpu:
                 args.append("--cpu")
-                if self._installed_backend is ServerBackend.xpu:
-                    env["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"  # see #1813
             elif self.backend is ServerBackend.directml:
                 args.append("--directml")
             if settings.server_arguments:

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -16,7 +16,7 @@ from .files import FileLibrary, FileFormat
 from .style import Style, StyleSettings, SamplerPresets
 from .resolution import ScaledExtent, ScaleMode, TileLayout, get_inpaint_reference
 from .resources import ControlMode, Arch, UpscalerName, ResourceKind, ResourceId
-from .settings import PerformanceSettings, ServerBackend
+from .settings import PerformanceSettings
 from .text import merge_prompt, extract_loras
 from .comfy_workflow import ComfyWorkflow, ComfyRunMode, Input, Output, ComfyNode
 from .localization import translate as _
@@ -713,14 +713,6 @@ def scale_refine_and_decode(
     else:
         assert mode is ScaleMode.upscale_quality
         upscaler = models.upscale[UpscalerName.default]
-
-    # if an canvas deviates both sizes from 1024 huge performance penalty tiled vae decreases it this is intel only
-    if (
-        extent.desired.width > 1536
-        or extent.desired.height > 1536
-        and settings.server_backend is ServerBackend.xpu
-    ):
-        tiled_vae = True
 
     upscale_model = w.load_upscale_model(upscaler)
     decoded = vae_decode(w, vae, latent, tiled_vae)


### PR DESCRIPTION
this "workaround" is not needed anymore with pytorch 2.8