### PR TITLE
Prevent job history misclick on new image row

### DIFF
--- a/ai_diffusion/ui/generation.py
+++ b/ai_diffusion/ui/generation.py
@@ -33,6 +33,8 @@ class HistoryWidget(QListWidget):
     item_activated = pyqtSignal(QListWidgetItem)
 
     _thumb_size = 96
+    _scroll_recent_ms = 10
+    _misclick_guard_ms = 300
     _applied_icon = Image.load(theme.icon_path / "star.png")
     _list_css = f"""
         QListWidget {{ background-color: transparent; }}
@@ -53,6 +55,19 @@ class HistoryWidget(QListWidget):
         super().__init__(parent)
         self._model = root.active_model
         self._connections = []
+        self._prev_scroll_max = 0
+        self._misclick_guard_active = False
+        self._misclick_guard_timer = QTimer(self)
+        self._misclick_guard_timer.setSingleShot(True)
+        self._misclick_guard_timer.timeout.connect(self._end_misclick_guard)
+        self._scroll_range_changed_recently = False
+        self._scrolled_to_bottom_recently = False
+        self._scroll_range_change_recent_timer = QTimer(self)
+        self._scroll_range_change_recent_timer.setSingleShot(True)
+        self._scroll_range_change_recent_timer.timeout.connect(self._end_scroll_range_change_recent)
+        self._scroll_recent_timer = QTimer(self)
+        self._scroll_recent_timer.setSingleShot(True)
+        self._scroll_recent_timer.timeout.connect(self._end_scroll_recent)
 
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.setResizeMode(QListView.Adjust)
@@ -83,6 +98,8 @@ class HistoryWidget(QListWidget):
         self._context_button.setFixedWidth(f.height() + 8)
         if scrollbar := self.verticalScrollBar():
             scrollbar.valueChanged.connect(self.update_apply_button)
+            scrollbar.rangeChanged.connect(self._on_scroll_range_changed)
+            self._prev_scroll_max = scrollbar.maximum()
 
         self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.customContextMenuRequested.connect(self._show_context_menu)
@@ -145,6 +162,9 @@ class HistoryWidget(QListWidget):
             self.addItem(item)
 
         if scroll_to_bottom:
+            self._mark_scrolled_to_bottom_recent()
+            if self._scroll_range_changed_recently:
+                self._start_misclick_guard()
             self.scrollToBottom()
 
     _job_info_translations = {
@@ -305,6 +325,9 @@ class HistoryWidget(QListWidget):
         self.clear()
         for job in filter(self.is_finished, self._model.jobs):
             self.add(job)
+        self._mark_scrolled_to_bottom_recent()
+        if self._scroll_range_changed_recently:
+            self._start_misclick_guard()
         self.scrollToBottom()
 
     def item_info(self, item: QListWidgetItem) -> tuple[str, int]:  # job id, image index
@@ -325,6 +348,9 @@ class HistoryWidget(QListWidget):
                 clipboard.setText(prompt)
 
     def mousePressEvent(self, e: QMouseEvent | None):
+        if e is not None and self._misclick_guard_active:
+            e.accept()
+            return
         if (  # make single click deselect current item (usually requires Ctrl+click)
             e is not None
             and e.button() == Qt.MouseButton.LeftButton
@@ -375,6 +401,8 @@ class HistoryWidget(QListWidget):
         return thumb.to_icon()
 
     def _show_context_menu(self, pos: QPoint):
+        if self._misclick_guard_active:
+            return
         item = self.itemAt(pos)
         if item is not None:
             job = self._model.jobs.find(self._item_data(item).job)
@@ -402,9 +430,36 @@ class HistoryWidget(QListWidget):
             menu.exec(self.mapToGlobal(pos))
 
     def _show_context_menu_dropdown(self):
+        if self._misclick_guard_active:
+            return
         pos = self._context_button.pos()
         pos.setY(pos.y() + self._context_button.height())
         self._show_context_menu(pos)
+
+    def _start_misclick_guard(self):
+        self._misclick_guard_active = True
+        self._misclick_guard_timer.start(self._misclick_guard_ms)
+
+    def _end_misclick_guard(self):
+        self._misclick_guard_active = False
+
+    def _mark_scrolled_to_bottom_recent(self):
+        self._scrolled_to_bottom_recently = True
+        self._scroll_recent_timer.start(self._scroll_recent_ms)
+
+    def _end_scroll_recent(self):
+        self._scrolled_to_bottom_recently = False
+
+    def _end_scroll_range_change_recent(self):
+        self._scroll_range_changed_recently = False
+
+    def _on_scroll_range_changed(self, _min: int, _max: int):
+        if _max > self._prev_scroll_max:
+            self._scroll_range_changed_recently = True
+            self._scroll_range_change_recent_timer.start(self._scroll_recent_ms)
+            if self._scrolled_to_bottom_recently:
+                self._start_misclick_guard()
+        self._prev_scroll_max = _max
 
     def _copy_prompt(self):
         if job := self.selected_job:


### PR DESCRIPTION
## Issue: Incorrect image deletion due to lag in job history UI causing mis-click

### Conditions:
* Image generation jobs already in progress and the results are coming in every few seconds, adding images to the job history UI
* The incoming image added causes the job history to scroll down (new job category or images wrapping to next line)
* Right clicking on an image within a fraction of a second after the latest image came in and caused a scroll
* Right click selects the new image in the new row when the user intended to select an image in the previous row.
### More Issue Details:
* Even though the image in the new row was selected by the right click, the highlight in the UI is sometimes still incorrectly on the old selected image.  This is not the case if the user waits a bit more time before right clicking the image in the history.  It only occurs in a small window of time where new images added.
* When selecting to delete the image from the opened context menu in this scenario, the new image gets deleted, even though the highlight is on the old image and the user thinks they are deleting the old image.
* The problem gets progressively worse the longer the job history gets, as I suppose there is some additional lag involved with adding new images at that point

### Fix discussion:
* Even if you could fix the highlight going on the wrong image, the user may be clicking through the right click context menu quickly enough to not stop their intended delete action before noticing the wrong image was going to deleted. I have done this dozens of times.
* You could disable all click actions and context menu open action on the job history UI for a a small window of time (300 ms) after a new image is added to the job history UI.  However, that happens when any images is added and not just when you are likely to mis-click (auto scroll).
* Better to detect when window scroll is likely to cause mis-click.
* Therefore, I think the best workaround solution is to disable all click actions and context menu open action on the job history for a small window of time (300 ms) after the job history window auto scrolls to the bottom and the scroll range changed.  If the user clicks any image during that window of time, no action occurs.  No image is selected and no context menu is opened.  The user must try to click again after the time window has passed.


This does fix the issue for me, but the solution is a little ugly, requiring 3 different timers.  Two to detect when the scroll to bottom and scroll range changed at the same time and one to guard against mis-clicking after that condition is detected.  If you have a more elegant or simpler solution to this problem, let me know.