### PR TITLE
zrok skip browser warning

### DIFF
--- a/ai_diffusion/comfy_client.py
+++ b/ai_diffusion/comfy_client.py
@@ -97,7 +97,7 @@ class ComfyClient(Client):
         self._is_connected = False
 
         self._requests.add_header("ngrok-skip-browser-warning", "69420")
-        self._requests.add_header(b"skip_zrok_interstitial", b"69420")
+        self._requests.add_header("skip_zrok_interstitial", "69420")
         if settings.server_authorization:
             self._requests.set_auth(settings.server_authorization)
 


### PR DESCRIPTION
Added the skip_zrok_interstitial header to HTTP requests to potentially bypass specific interstitials or warnings.

New PR after rebase from [https://github.com/Acly/krita-ai-diffusion/pull/2088#issue-3507263964]()