### PR TITLE
Metadata output fix for custom sampler presets

### DIFF
--- a/ai_diffusion/text.py
+++ b/ai_diffusion/text.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 import re
 from pathlib import Path
-from typing import Tuple, List, NamedTuple
+from typing import Tuple, List, NamedTuple, Optional
+
 
 from .api import LoraInput
 from .files import FileCollection, FileSource
@@ -230,6 +231,7 @@ def edit_attention(text: str, positive: bool) -> str:
         else f"{open_bracket}{attention_string}:{weight:.1f}{close_bracket}"
     )
 
+
 # in case a custom sampler is used then it may show steps and cfg in there
 def _parse_sampler_embeds(sampler: str) -> Tuple[str, Optional[int], Optional[float]]:
     """
@@ -265,6 +267,7 @@ def _parse_sampler_embeds(sampler: str) -> Tuple[str, Optional[int], Optional[fl
         steps_in, cfg_in = None, None
 
     return base, steps_in, cfg_in
+
 
 # creates the img text metadata for embedding in PNG files in style like Automatic1111
 def create_img_metadata(params: JobParams):

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -5,7 +5,7 @@ from ai_diffusion.text import (
     select_on_cursor_pos,
     create_img_metadata,
     strip_prompt_comments,
-    _parse_sampler_embeds
+    _parse_sampler_embeds,
 )
 from ai_diffusion.api import LoraInput
 from ai_diffusion.files import File, FileCollection
@@ -222,6 +222,7 @@ def test_create_img_metadata_missing_metadata_fields():
     assert "Size: 100x200" in result
     assert "Model: Unknown" in result
 
+
 def test_create_img_metadata_sampler_embedded():
     bounds = Bounds(0, 0, 832, 1216)
     metadata = {
@@ -247,6 +248,7 @@ def test_create_img_metadata_sampler_embedded():
     assert "Size: 832x1216" in result
     assert "Denoising strength" not in result
 
+
 def test_parse_sampler_embeds():
     assert _parse_sampler_embeds("") == ("", None, None)
     assert _parse_sampler_embeds("Euler") == ("Euler", None, None)
@@ -254,6 +256,7 @@ def test_parse_sampler_embeds():
     assert _parse_sampler_embeds("LCM(13/1.1)") == ("LCM", 13, 1.1)
     assert _parse_sampler_embeds("LCM (13)") == ("LCM", 13, None)
     assert _parse_sampler_embeds("LCM (13,1.1)") == ("LCM", 13, 1.1)
+
 
 class TestEditAttention:
     def test_empty_selection(self):


### PR DESCRIPTION
Addresses #2012

Steps and CFG are not set correctly when using a custom setting for sampler with a custom preset.

The user said metadata not showing up when uploaded to CivitAI.  After the user supplied more information and sample file it became obvious that three things were different from the normal saving of metadata which usually works.

- Steps were unknown
- CFG scale was unknown
- The sampler showed additional information besides the sampler name.
  -  It was supplied that way from the Job params rather than these pieces of information coming in under the normal params as `steps` and `guidance`.

After downloading the same model safetensors file and having to set it up with a custom preset for the sampler to use lcm I was able to duplicate the problem.

This PR supplies a fallback for obtaining these settings from the sampler name when they aren't supplied normally in the JobParams if a custom preset is used that isn't built in.

This is a sample upload on civitai after the fix and it fills the steps and cfg to it so it seems to be happier.

<img width="1000" height="746" alt="Screenshot 2025-11-01 193834" src="https://github.com/user-attachments/assets/a7d398e6-4ad9-4fb1-b07d-9b7047b6429f" />

I updated, ran test, ruff, etc.
