### PR TITLE
Add support for Style & Prompt node in custom workflows

### DIFF
--- a/ai_diffusion/api.py
+++ b/ai_diffusion/api.py
@@ -169,6 +169,10 @@ class UpscaleInput:
 class CustomWorkflowInput:
     workflow: dict
     params: dict[str, Any]
+    positive_evaluated: str = ""
+    negative_evaluated: str = ""
+    models: CheckpointInput | None = None
+    sampling: SamplingInput | None = None
 
 
 @dataclass

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -1420,6 +1420,20 @@ def expand_custom(
                 outputs[node.output(6)] = sampling.scheduler
                 outputs[node.output(7)] = sampling.total_steps
                 outputs[node.output(8)] = sampling.cfg_scale
+
+            case "ETN_KritaStyleAndPrompt":
+                checkpoint_input = ensure(input.models)
+                sampling = ensure(input.sampling)
+                model, clip, vae = load_checkpoint_with_lora(w, checkpoint_input, models)
+                outputs[node.output(0)] = model
+                outputs[node.output(1)] = clip.model
+                outputs[node.output(2)] = vae
+                outputs[node.output(3)] = input.positive_evaluated
+                outputs[node.output(4)] = input.negative_evaluated
+                outputs[node.output(5)] = sampling.sampler
+                outputs[node.output(6)] = sampling.scheduler
+                outputs[node.output(7)] = sampling.total_steps
+                outputs[node.output(8)] = sampling.cfg_scale
             case _:
                 mapped_inputs = {k: map_input(v) for k, v in node.inputs.items()}
                 mapped = ComfyNode(node.id, node.type, mapped_inputs)


### PR DESCRIPTION
https://github.com/Acly/comfyui-tooling-nodes/pull/57

Closes https://github.com/Acly/krita-ai-diffusion/issues/1380

Features:
- Prompts and Style sync across Generate/Live/Animation and now Graph workspaces
- Full prompt evaluation: wildcards, comments, style merging, LoRA extraction (uses existing implementation, no code duplication)
- LoRAs applied to model output
- Error shown if workflow contains multiple KritaPromptStyle nodes (only one allowed since prompts sync to shared fields)
- "Copy Prompt", "Copy Prompt (Evaluated)", "Copy Style" works as expected across workspaces

<img width="945" height="505" src="https://github.com/user-attachments/assets/98a23a07-91f3-4957-be80-6b16bb801134" />

<img width="1427" height="881" src="https://github.com/user-attachments/assets/ae1a501c-e339-4f86-a1d5-5eeee8139507" />
