### PR TITLE
Fix missing controlnet range slider for models that support traditional controlnets

### DIFF
--- a/ai_diffusion/control.py
+++ b/ai_diffusion/control.py
@@ -172,7 +172,7 @@ class ControlLayer(QObject, ObservableProperties):
                     self.error_text = _("Not supported for") + f" {models.arch.value}"
             elif self.mode.is_control_net:
                 model = models.find_control(self.mode)
-                self.has_range = model == models.model_patch.find(self.mode, True)
+                self.has_range = model == models.control.find(self.mode, True)
                 if model is None:
                     search_arch = Arch.illu if models.arch is Arch.illu_v else models.arch
                     search_path = (


### PR DESCRIPTION
It seems you made an error in 1.46.0 where you are checking for `has_range` in ` models.model_patch.find(self.mode, True)`  instead of  `models.control.find(self.mode, True)` resulting in range slider being hidden in all SD and SDXL models
This fix this issue.