### PR TITLE
fix: missing access_token for external, new http websocket header property

### DIFF
--- a/ai_diffusion/__init__.py
+++ b/ai_diffusion/__init__.py
@@ -1,6 +1,6 @@
 """Generative AI plugin for Krita"""
 
-__version__ = "1.49.1"
+__version__ = "1.49.0"
 
 import importlib.util
 

--- a/ai_diffusion/connection.py
+++ b/ai_diffusion/connection.py
@@ -96,7 +96,7 @@ class Connection(QObject, ObservableProperties):
                     return
                 self._client = await CloudClient.connect(CloudClient.default_api_url, access_token)
             else:
-                self._client = await ComfyClient.connect(url,access_token)
+                self._client = await ComfyClient.connect(url, access_token)
                 self.state = ConnectionState.discover_models
                 async for status in self._client.discover_models(refresh=False):
                     self.progress = (status.current, status.total)

--- a/ai_diffusion/resources.py
+++ b/ai_diffusion/resources.py
@@ -10,7 +10,7 @@ from typing import Any, NamedTuple
 
 # Version identifier for all the resources defined here. This is used as the server version.
 # It usually follows the plugin version, but not all new plugin versions also require a server update.
-version = "1.49.1"
+version = "1.49.0"
 
 comfy_url = "https://github.com/comfyanonymous/ComfyUI"
 comfy_version = "a11f68dd3b5393b6afc37e01c91fa84963d2668a"


### PR DESCRIPTION
This PR would fix:
- missing access_token(s) and authorization settings to be able to communicate with external services (like Vast.ai)
- updates websocket deprecated header property from `extra_headers` to `additional_headers` instead

**Note:** As this is my first PR in this nice project, I would like to get more insights if I made some issues. Thanks!  