### PR TITLE
Adding in new Krita Group Layer node

### DIFF
--- a/ai_diffusion/api.py
+++ b/ai_diffusion/api.py
@@ -175,6 +175,12 @@ class CustomStyleInput:
 
 
 @dataclass
+class CustomLayerInput:
+    images: ImageCollection
+    names: list[str]
+
+
+@dataclass
 class CustomWorkflowInput:
     workflow: dict
     params: dict[str, Any]

--- a/ai_diffusion/api.py
+++ b/ai_diffusion/api.py
@@ -176,8 +176,9 @@ class CustomStyleInput:
 
 @dataclass
 class CustomLayerInput:
-    images: ImageCollection
+    images: Image | ImageCollection
     names: list[str]
+    is_batch: bool
 
 
 @dataclass

--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -1033,6 +1033,9 @@ class ComfyWorkflow:
     def batch_image(self, batch: Output, image: Output):
         return self.add("ImageBatch", 1, image1=batch, image2=image)
 
+    def unbatch_image(self, image: Output):
+        return self.add("RebatchImages", 1, images=image, batch_size=1)
+
     def image_batch_element(self, batch: Output, index: int):
         return self.add("ImageFromBatch", 1, image=batch, batch_index=index, length=1)
 
@@ -1112,6 +1115,10 @@ class ComfyWorkflow:
         image_batch = self.mask_to_image(batch)
         image = self.mask_to_image(mask)
         return self.image_to_mask(self.batch_image(image_batch, image))
+
+    def unbatch_mask(self, mask: Output):
+        image = self.mask_to_image(mask)
+        return self.image_to_mask(self.unbatch_image(image))
 
     def mask_batch_element(self, mask_batch: Output, index: int):
         image_batch = self.mask_to_image(mask_batch)

--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -1208,6 +1208,9 @@ class ComfyWorkflow:
         return result
 
     def send_list(self, list: list[Input]):
+        if len(list) == 1:
+            return list[0]
+
         output = self.add("ETN_ListEmpty", 1)
 
         for item in list:

--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -1200,6 +1200,14 @@ class ComfyWorkflow:
         assert result is not None
         return result
 
+    def send_list_str(self, list: list[str]):
+        output = self.add("ETN_ListEmpty", 1)
+
+        for item in list:
+            output = self.add("ETN_ListAppend", 1, list=output, item=item)
+
+        return self.add("ETN_DataList", 1, list=output)
+
     def send_image(self, image: Output):
         if self._run_mode is ComfyRunMode.runtime:
             return self.add("ETN_ReturnImage", 1, images=image)

--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -1207,7 +1207,7 @@ class ComfyWorkflow:
         assert result is not None
         return result
 
-    def send_list_str(self, list: list[str]):
+    def send_list(self, list: list[Input]):
         output = self.add("ETN_ListEmpty", 1)
 
         for item in list:

--- a/ai_diffusion/custom_workflow.py
+++ b/ai_diffusion/custom_workflow.py
@@ -21,11 +21,11 @@ from PyQt5.QtCore import (
 )
 
 from . import eventloop
-from .api import CustomStyleInput, InpaintContext, WorkflowInput
+from .api import CustomStyleInput, CustomLayerInput, InpaintContext, WorkflowInput
 from .client import ClientModels, ClientOutput, JobInfoOutput, OutputBatchMode, TextOutput
 from .comfy_workflow import ComfyNode, ComfyWorkflow
 from .connection import Connection, ConnectionState
-from .image import Bounds, Image, Mask
+from .image import Bounds, Image, Mask, ImageCollection
 from .jobs import Job, JobKind, JobParams, JobQueue
 from .localization import translate as _
 from .properties import ObservableProperties, Property
@@ -259,14 +259,15 @@ class SortedWorkflows(QSortFilterProxyModel):
 class ParamKind(Enum):
     image_layer = 0
     mask_layer = 1
-    number_int = 2
-    number_float = 3
-    toggle = 4
-    text = 5
-    prompt_positive = 6
-    prompt_negative = 7
-    choice = 8
-    style = 9
+    group_layer = 2
+    number_int = 3
+    number_float = 4
+    toggle = 5
+    text = 6
+    prompt_positive = 7
+    prompt_negative = 8
+    choice = 9
+    style = 10
 
 
 class CustomParam(NamedTuple):
@@ -327,6 +328,9 @@ def workflow_parameters(w: ComfyWorkflow):
             case ("ETN_KritaMaskLayer", _):
                 name = node.input("name", "Mask")
                 yield CustomParam(ParamKind.mask_layer, name)
+            case ("ETN_KritaGroupLayer", _):
+                name = node.input("name", "Group")
+                yield CustomParam(ParamKind.group_layer, name)
             case ("ETN_Parameter", "number (integer)"):
                 name = node.input("name", "Parameter")
                 default = node.input("default", 0)
@@ -565,6 +569,7 @@ class CustomWorkspace(QObject, ObservableProperties):
                     params[md.name] = layer.get_pixel_frames(bounds)
                 else:
                     params[md.name] = layer.get_pixels(bounds)
+
             elif md.kind is ParamKind.mask_layer:
                 if param is None and len(layers.masks) > 0:
                     param = layers.masks[0].id
@@ -575,6 +580,24 @@ class CustomWorkspace(QObject, ObservableProperties):
                     params[md.name] = layer.get_mask_frames(bounds)
                 else:
                     params[md.name] = layer.get_mask(bounds)
+
+            elif md.kind is ParamKind.group_layer:
+                if param is None and len(layers.images) > 0:
+                    param = layers.images[0].id
+                layer = layers.find(QUuid(param))
+                if layer is None:
+                    raise ValueError(f"Input layer for parameter {md.name} not found")
+
+                children = list(layer.get_child_images(bounds))
+
+                names = [name for (name, image) in children]
+                images = [image for (name, image) in children]
+
+                params[md.name] = CustomLayerInput(
+                    ImageCollection(images),
+                    names,
+                )
+
             elif md.kind is ParamKind.style:
                 style = Styles.list().find(str(param))
                 if style is None:

--- a/ai_diffusion/custom_workflow.py
+++ b/ai_diffusion/custom_workflow.py
@@ -259,15 +259,14 @@ class SortedWorkflows(QSortFilterProxyModel):
 class ParamKind(Enum):
     image_layer = 0
     mask_layer = 1
-    group_layer = 2
-    number_int = 3
-    number_float = 4
-    toggle = 5
-    text = 6
-    prompt_positive = 7
-    prompt_negative = 8
-    choice = 9
-    style = 10
+    number_int = 2
+    number_float = 3
+    toggle = 4
+    text = 5
+    prompt_positive = 6
+    prompt_negative = 7
+    choice = 8
+    style = 9
 
 
 class CustomParam(NamedTuple):
@@ -324,13 +323,10 @@ def workflow_parameters(w: ComfyWorkflow):
                 yield CustomParam(ParamKind.style, name, node.input("sampler_preset", "auto"))
             case ("ETN_KritaImageLayer", _):
                 name = node.input("name", "Image")
-                yield CustomParam(ParamKind.image_layer, name)
+                yield CustomParam(ParamKind.image_layer, name, node.input("group_mode", "flatten"))
             case ("ETN_KritaMaskLayer", _):
                 name = node.input("name", "Mask")
                 yield CustomParam(ParamKind.mask_layer, name)
-            case ("ETN_KritaGroupLayer", _):
-                name = node.input("name", "Group")
-                yield CustomParam(ParamKind.group_layer, name)
             case ("ETN_Parameter", "number (integer)"):
                 name = node.input("name", "Parameter")
                 default = node.input("default", 0)
@@ -565,10 +561,35 @@ class CustomWorkspace(QObject, ObservableProperties):
                 layer = layers.find(QUuid(param))
                 if layer is None:
                     raise ValueError(f"Input layer for parameter {md.name} not found")
+
                 if is_animation and layer.is_animated:
-                    params[md.name] = layer.get_pixel_frames(bounds)
+                    params[md.name] = CustomLayerInput(
+                        layer.get_pixel_frames(bounds),
+                        [layer.name],
+                        True,
+                    )
+
+                elif md.default == "flatten":
+                    params[md.name] = CustomLayerInput(
+                        layer.get_pixels(bounds),
+                        [layer.name],
+                        True,
+                    )
+
+                elif md.default == "all children":
+                    children = list(layer.get_child_images(bounds))
+
+                    names = [name for (name, image) in children]
+                    images = [image for (name, image) in children]
+
+                    params[md.name] = CustomLayerInput(
+                        ImageCollection(images),
+                        names,
+                        False,
+                    )
+
                 else:
-                    params[md.name] = layer.get_pixels(bounds)
+                    raise ValueError(f"Unknown group_mode {md.default}")
 
             elif md.kind is ParamKind.mask_layer:
                 if param is None and len(layers.masks) > 0:
@@ -580,23 +601,6 @@ class CustomWorkspace(QObject, ObservableProperties):
                     params[md.name] = layer.get_mask_frames(bounds)
                 else:
                     params[md.name] = layer.get_mask(bounds)
-
-            elif md.kind is ParamKind.group_layer:
-                if param is None and len(layers.images) > 0:
-                    param = layers.images[0].id
-                layer = layers.find(QUuid(param))
-                if layer is None:
-                    raise ValueError(f"Input layer for parameter {md.name} not found")
-
-                children = list(layer.get_child_images(bounds))
-
-                names = [name for (name, image) in children]
-                images = [image for (name, image) in children]
-
-                params[md.name] = CustomLayerInput(
-                    ImageCollection(images),
-                    names,
-                )
 
             elif md.kind is ParamKind.style:
                 style = Styles.list().find(str(param))

--- a/ai_diffusion/custom_workflow.py
+++ b/ai_diffusion/custom_workflow.py
@@ -21,11 +21,11 @@ from PyQt5.QtCore import (
 )
 
 from . import eventloop
-from .api import CustomStyleInput, CustomLayerInput, InpaintContext, WorkflowInput
+from .api import CustomLayerInput, CustomStyleInput, InpaintContext, WorkflowInput
 from .client import ClientModels, ClientOutput, JobInfoOutput, OutputBatchMode, TextOutput
 from .comfy_workflow import ComfyNode, ComfyWorkflow
 from .connection import Connection, ConnectionState
-from .image import Bounds, Image, Mask, ImageCollection
+from .image import Bounds, Image, ImageCollection, Mask
 from .jobs import Job, JobKind, JobParams, JobQueue
 from .localization import translate as _
 from .properties import ObservableProperties, Property

--- a/ai_diffusion/layer.py
+++ b/ai_diffusion/layer.py
@@ -213,6 +213,14 @@ class Layer(QObject):
     def get_mask_frames(self, bounds: Bounds | None = None):
         return self._get_frames(self.get_mask, bounds)
 
+    def get_child_images(self, bounds: Bounds | None = None):
+        if self.type is LayerType.group:
+            for child in self.child_layers:
+                yield from child.get_child_images(bounds)
+
+        elif self.type.is_image:
+            yield (self.name, self.get_pixels(bounds))
+
     def move_to_top(self):
         parent = self._node.parentNode()
         if acquire_elements(parent.childNodes())[-1] == self._node:

--- a/ai_diffusion/ui/custom_workflow.py
+++ b/ai_diffusion/ui/custom_workflow.py
@@ -429,8 +429,6 @@ def _create_param_widget(param: CustomParam, parent: "WorkflowParamsWidget") -> 
             return LayerSelect("image", parent)
         case ParamKind.mask_layer:
             return LayerSelect("mask", parent)
-        case ParamKind.group_layer:
-            return LayerSelect("image", parent)
         case ParamKind.number_int:
             return IntParamWidget(param, parent)
         case ParamKind.number_float:

--- a/ai_diffusion/ui/custom_workflow.py
+++ b/ai_diffusion/ui/custom_workflow.py
@@ -429,6 +429,8 @@ def _create_param_widget(param: CustomParam, parent: "WorkflowParamsWidget") -> 
             return LayerSelect("image", parent)
         case ParamKind.mask_layer:
             return LayerSelect("mask", parent)
+        case ParamKind.group_layer:
+            return LayerSelect("image", parent)
         case ParamKind.number_int:
             return IntParamWidget(param, parent)
         case ParamKind.number_float:

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -1467,8 +1467,8 @@ def expand_custom(
             case "ETN_KritaGroupLayer":
                 layer: CustomLayerInput = get_param(node, CustomLayerInput)
                 img, mask = w.load_image_and_mask(layer.images)
-                outputs[node.output(0)] = img
-                outputs[node.output(1)] = mask
+                outputs[node.output(0)] = w.unbatch_image(img)
+                outputs[node.output(1)] = w.unbatch_mask(mask)
                 outputs[node.output(2)] = w.send_list_str(layer.names)
             case "ETN_KritaStyle":
                 style: CustomStyleInput = get_param(node, CustomStyleInput)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -11,6 +11,7 @@ from .api import (
     CheckpointInput,
     ConditioningInput,
     ControlInput,
+    CustomLayerInput,
     CustomStyleInput,
     CustomWorkflowInput,
     ExtentInput,
@@ -1463,6 +1464,12 @@ def expand_custom(
                 outputs[node.output(1)] = mask
             case "ETN_KritaMaskLayer":
                 outputs[node.output(0)] = w.load_mask(get_param(node, (Image, ImageCollection)))
+            case "ETN_KritaGroupLayer":
+                layer: CustomLayerInput = get_param(node, CustomLayerInput)
+                img, mask = w.load_image_and_mask(layer.images)
+                outputs[node.output(0)] = img
+                outputs[node.output(1)] = mask
+                outputs[node.output(2)] = w.send_list_str(layer.names)
             case "ETN_KritaStyle":
                 style: CustomStyleInput = get_param(node, CustomStyleInput)
                 model, clip, vae = load_checkpoint_with_lora(w, style.models, models)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -1459,17 +1459,16 @@ def expand_custom(
             case "ETN_Parameter":
                 outputs[node.output(0)] = get_param(node)
             case "ETN_KritaImageLayer":
-                img, mask = w.load_image_and_mask(get_param(node, (Image, ImageCollection)))
-                outputs[node.output(0)] = img
-                outputs[node.output(1)] = mask
-            case "ETN_KritaMaskLayer":
-                outputs[node.output(0)] = w.load_mask(get_param(node, (Image, ImageCollection)))
-            case "ETN_KritaGroupLayer":
                 layer: CustomLayerInput = get_param(node, CustomLayerInput)
                 img, mask = w.load_image_and_mask(layer.images)
-                outputs[node.output(0)] = w.unbatch_image(img)
-                outputs[node.output(1)] = w.unbatch_mask(mask)
+                if not layer.is_batch:
+                    img = w.unbatch_image(img)
+                    mask = w.unbatch_mask(mask)
+                outputs[node.output(0)] = img
+                outputs[node.output(1)] = mask
                 outputs[node.output(2)] = w.send_list_str(layer.names)
+            case "ETN_KritaMaskLayer":
+                outputs[node.output(0)] = w.load_mask(get_param(node, (Image, ImageCollection)))
             case "ETN_KritaStyle":
                 style: CustomStyleInput = get_param(node, CustomStyleInput)
                 model, clip, vae = load_checkpoint_with_lora(w, style.models, models)

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -1466,7 +1466,7 @@ def expand_custom(
                     mask = w.unbatch_mask(mask)
                 outputs[node.output(0)] = img
                 outputs[node.output(1)] = mask
-                outputs[node.output(2)] = w.send_list_str(layer.names)
+                outputs[node.output(2)] = w.send_list(layer.names)
             case "ETN_KritaMaskLayer":
                 outputs[node.output(0)] = w.load_mask(get_param(node, (Image, ImageCollection)))
             case "ETN_KritaStyle":

--- a/tests/test_custom_workflow.py
+++ b/tests/test_custom_workflow.py
@@ -341,9 +341,8 @@ def test_parameters():
     w.add("ChoiceNode", 1, choice_param=choice_param)
     choice_param_v3 = w.add("ETN_Parameter", 1, name="choice_v3", type="choice", default="c")
     w.add("ChoiceNodeV3", 1, choice_param=choice_param_v3)
-    w.add("ETN_KritaImageLayer", 1, name="image")
+    w.add("ETN_KritaImageLayer", 3, name="image")
     w.add("ETN_KritaMaskLayer", 1, name="mask")
-    w.add("ETN_KritaGroupLayer", 3, name="group")
     w.add("ETN_KritaStyle", 9, name="style", sampler_preset="live")  # type: ignore
 
     assert list(workflow_parameters(w)) == [
@@ -358,7 +357,6 @@ def test_parameters():
         CustomParam(ParamKind.choice, "choice_v3", "c", choices=["a", "b", "c"]),
         CustomParam(ParamKind.image_layer, "image"),
         CustomParam(ParamKind.mask_layer, "mask"),
-        CustomParam(ParamKind.group_layer, "group"),
         CustomParam(ParamKind.style, "style", "live"),
     ]
 

--- a/tests/test_custom_workflow.py
+++ b/tests/test_custom_workflow.py
@@ -343,6 +343,7 @@ def test_parameters():
     w.add("ChoiceNodeV3", 1, choice_param=choice_param_v3)
     w.add("ETN_KritaImageLayer", 1, name="image")
     w.add("ETN_KritaMaskLayer", 1, name="mask")
+    w.add("ETN_KritaGroupLayer", 3, name="group")
     w.add("ETN_KritaStyle", 9, name="style", sampler_preset="live")  # type: ignore
 
     assert list(workflow_parameters(w)) == [
@@ -357,6 +358,7 @@ def test_parameters():
         CustomParam(ParamKind.choice, "choice_v3", "c", choices=["a", "b", "c"]),
         CustomParam(ParamKind.image_layer, "image"),
         CustomParam(ParamKind.mask_layer, "mask"),
+        CustomParam(ParamKind.group_layer, "group"),
         CustomParam(ParamKind.style, "style", "live"),
     ]
 


### PR DESCRIPTION
Currently there are three ways to send images to ComfyUI: `Krita Canvas`, `Krita Image Layer`, and `Krita Mask Layer`.

This adds a new `Krita Group Layer` node that sends an entire group of image layers to ComfyUI (along with the masks and names of each image layer).

This is really useful for a variety of situations:

* Sending multiple animation frames outside of `Generate Animation` mode.
* Sending multiple image masks all at once without needing to send them individually.
* Processing an entire batch of images at the same time (upscaling, detailing, etc.)

Originally I wanted to add this feature to the existing `Krita Image Layer` and `Krita Mask Layer` nodes, but that would have needed significant code refactoring. So I made a new node instead.