### PR TITLE
Security: Zip Slip vulnerability in auto-update extraction

### DIFF
--- a/ai_diffusion/updates.py
+++ b/ai_diffusion/updates.py
@@ -119,6 +119,10 @@ class AutoUpdate(QObject, ObservableProperties):
         log.info(f"Extracting plugin archive into {source_dir}")
         self.state = UpdateState.installing
         with ZipFile(archive_path) as zip_file:
+            for info in zip_file.infolist():
+                target = (source_dir / info.filename).resolve()
+                if not target.is_relative_to(source_dir.resolve()):
+                    raise RuntimeError(f"Zip entry escapes target directory: {info.filename}")
             zip_file.extractall(source_dir)
 
         log.info(f"Installing new plugin version to {self.plugin_dir}")


### PR DESCRIPTION
## Problem

The `_run` method in `AutoUpdate` uses `ZipFile.extractall()` to extract a downloaded update archive without validating that archive entries don't contain path traversal sequences (e.g., `../`). Python's `zipfile.extractall()` does not fully protect against Zip Slip attacks in all versions. If the update server is compromised (or redirected via environment variable), a crafted archive could write files outside the intended directory. The extracted files are then copied over the plugin installation via `shutil.copytree` with `dirs_exist_ok=True`.

**Severity**: `high`
**File**: `ai_diffusion/updates.py`

## Solution

Validate each entry in the zip archive before extraction by checking that the resolved path stays within the intended target directory. Use `zipfile.Path` or manually check each `ZipInfo.filename` does not contain `..` components or absolute paths. In Python 3.12+, use `zip_file.extractall(source_dir, filter='data')`.

## Changes

- `ai_diffusion/updates.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
