### PR TITLE
Security: Update server URL controllable via environment variable enables supply chain attack

### DIFF
--- a/ai_diffusion/updates.py
+++ b/ai_diffusion/updates.py
@@ -34,7 +34,7 @@ class UpdatePackage(NamedTuple):
 
 
 class AutoUpdate(QObject, ObservableProperties):
-    default_api_url = os.getenv("INTERSTICE_URL", "https://api.interstice.cloud")
+    default_api_url = "https://api.interstice.cloud"
 
     state = Property(UpdateState.unknown)
     latest_version = Property("")


### PR DESCRIPTION
## Problem

The `default_api_url` for the auto-update mechanism is read from the `INTERSTICE_URL` environment variable. An attacker who can set this environment variable can redirect update checks to a malicious server. Since the attacker-controlled server provides both the download URL and the SHA256 hash, the hash verification becomes ineffective — the attacker can serve a malicious package with a matching hash. This leads to arbitrary code execution when the plugin is updated.

**Severity**: `high`
**File**: `ai_diffusion/updates.py`

## Solution

Hardcode the API URL instead of reading from an environment variable, or only allow environment variable overrides in development/test builds. Consider using code signing or a pinned TLS certificate to verify the update server identity independently of the URL.

## Changes

- `ai_diffusion/updates.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
