### PR TITLE
Security: Path traversal in language file loading

### DIFF
--- a/ai_diffusion/localization.py
+++ b/ai_diffusion/localization.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 from typing import NamedTuple
 
@@ -71,6 +72,10 @@ class Localization:
                     language = settings.get("language", "en")
             except Exception as e:
                 log.warning(f"Could not read language settings: {e}")
+
+        if not re.match(r'^[a-zA-Z0-9_-]+$', language):
+            log.warning(f"Invalid language identifier: {language}")
+            language = "en"
 
         language_file = Path(__file__).parent / "language" / f"{language}.json"
         try:


### PR DESCRIPTION
## Problem

The `Localization.init()` method reads a `language` string from the user's `settings.json` file and directly interpolates it into a file path: `f"{language}.json"`. If the `language` value contains directory traversal characters (e.g., `../../etc/passwd`), it could cause the application to attempt to load and parse arbitrary JSON files outside the intended language directory.

**Severity**: `medium`
**File**: `ai_diffusion/localization.py`

## Solution

Sanitize the language identifier to only allow alphanumeric characters and hyphens/underscores, e.g., `import re; if not re.match(r'^[a-zA-Z0-9_-]+$', language): language = 'en'`. Alternatively, resolve the path and verify it remains within the language directory.

## Changes

- `ai_diffusion/localization.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
