### PR TITLE
Security: Debug Port Unconditionally Opened When debugpy Directory Exists

### DIFF
--- a/ai_diffusion/extension.py
+++ b/ai_diffusion/extension.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -24,7 +25,7 @@ class AIToolsExtension(Extension):
 
         extension_dir = Path(__file__).parent
         debugpy_path = extension_dir / "debugpy" / "src"
-        if debugpy_path.exists():
+        if os.environ.get("AI_DIFFUSION_DEBUG") == "1" and debugpy_path.exists():
             try:
                 sys.path.insert(0, str(debugpy_path))
                 import debugpy


### PR DESCRIPTION
## Problem

The extension checks for the existence of a `debugpy/src` directory and, if found, opens a debug listener on `127.0.0.1:5678` with `in_process_debug_adapter=True`. Any local process can connect to this port and execute arbitrary Python code within the Krita process. If the debugpy directory is accidentally shipped or created, this creates a local privilege escalation / code execution vector.

**Severity**: `medium`
**File**: `ai_diffusion/extension.py`

## Solution

Add an explicit opt-in mechanism (e.g., an environment variable like `AI_DIFFUSION_DEBUG=1`) rather than relying solely on directory existence. Ensure the debugpy directory is excluded from release packages (verify `.gitignore` and packaging scripts).

## Changes

- `ai_diffusion/extension.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
