### PR TITLE
Security: Potential Zip Slip in Windows LongPathZipFile Override

### DIFF
--- a/ai_diffusion/platform_tools.py
+++ b/ai_diffusion/platform_tools.py
@@ -95,8 +95,11 @@ class LongPathZipFile(zipfile.ZipFile):
     # zipfile.ZipFile does not support long paths (260+?) on Windows
     # for latest python, changing cwd and using relative paths helps, but not for python in Krita 5.2
     def _extract_member(self, member, targetpath, pwd):
-        # Prepend \\?\ to targetpath to bypass MAX_PATH limit
         targetpath = os.path.abspath(targetpath)
+        member_name = member.filename if not isinstance(member, str) else member
+        extract_path = os.path.normpath(os.path.join(targetpath, member_name))
+        if not extract_path.startswith(targetpath + os.sep) and extract_path != targetpath:
+            raise ValueError(f"Zip member path would escape target directory: {member_name!r}")
         if targetpath.startswith("\\\\"):
             targetpath = "\\\\?\\UNC\\" + targetpath[2:]
         else:


### PR DESCRIPTION
## Problem

The `LongPathZipFile._extract_member` override prepends `\\?\` to the target path after calling `os.path.abspath`. Python's built-in zip slip protection in `zipfile._extract_member` compares the resolved output path against the target directory. The `\\?\` prefix modification may cause the path prefix comparison to fail, potentially allowing a crafted zip with `../` entries to write files outside the intended extraction directory on Windows.

**Severity**: `high`
**File**: `ai_diffusion/platform_tools.py`

## Solution

After extraction, validate that all extracted file paths are within the expected target directory. Alternatively, iterate zip members before extraction and reject any entry whose resolved path escapes the target directory. Consider using `zipfile.Path` or manual member-by-member extraction with explicit path validation.

## Changes

- `ai_diffusion/platform_tools.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
