### PR TITLE
Security: Debug Adapter (debugpy) Listening on Fixed Port Enables Remote Code Execution

### DIFF
--- a/ai_diffusion/extension.py
+++ b/ai_diffusion/extension.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -24,13 +25,13 @@ class AIToolsExtension(Extension):
 
         extension_dir = Path(__file__).parent
         debugpy_path = extension_dir / "debugpy" / "src"
-        if debugpy_path.exists():
+        if os.environ.get("AI_DIFFUSION_DEBUG") == "1" and debugpy_path.exists():
             try:
                 sys.path.insert(0, str(debugpy_path))
                 import debugpy
 
                 debugpy.listen(("127.0.0.1", 5678), in_process_debug_adapter=True)
-                log.info("Developer mode: debugpy listening on port 5678")
+                log.warning("Developer mode: debugpy listening on 127.0.0.1:5678")
             except ImportError:
                 pass
 


### PR DESCRIPTION
## Problem

The extension unconditionally starts a debugpy debug adapter listening on port 5678 if the `debugpy` directory exists under the plugin folder. Any local process (or remote process if the machine is network-accessible) can connect to this port and execute arbitrary Python code within Krita's process. The listener is started without authentication and the port is hardcoded, making it predictable for attackers.

**Severity**: `critical`
**File**: `ai_diffusion/extension.py`

## Solution

Gate debugpy activation behind an explicit environment variable (e.g., `AI_DIFFUSION_DEBUG=1`) rather than just checking for directory existence. Also consider logging a prominent warning and binding only to `127.0.0.1` with a configurable port.

## Changes

- `ai_diffusion/extension.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
