### PR TITLE
Security: Potential Zip Slip via Custom ZipFile Path Modification

### DIFF
--- a/ai_diffusion/platform_tools.py
+++ b/ai_diffusion/platform_tools.py
@@ -95,6 +95,10 @@ class LongPathZipFile(zipfile.ZipFile):
     # zipfile.ZipFile does not support long paths (260+?) on Windows
     # for latest python, changing cwd and using relative paths helps, but not for python in Krita 5.2
     def _extract_member(self, member, targetpath, pwd):
+        member_path = member.filename if isinstance(member, zipfile.ZipInfo) else member
+        parts = member_path.replace("\\", "/").split("/")
+        if any(p == ".." for p in parts) or os.path.isabs(member_path):
+            raise ValueError(f"Refused to extract zip member with unsafe path: {member_path!r}")
         # Prepend \\?\ to targetpath to bypass MAX_PATH limit
         targetpath = os.path.abspath(targetpath)
         if targetpath.startswith("\\\\"):


### PR DESCRIPTION
## Problem

The `LongPathZipFile._extract_member` method modifies `targetpath` by prepending `\\?\` for Windows long path support, then delegates to the parent `_extract_member`. Python's `zipfile.ZipFile._extract_member` performs path traversal checks relative to the `targetpath`. By modifying `targetpath` after `os.path.abspath()` but before the security check in the parent, the relationship between the normalized target path and member paths could be altered, potentially allowing a crafted zip entry to extract files outside the intended directory.

**Severity**: `medium`
**File**: `ai_diffusion/platform_tools.py`

## Solution

Validate zip member paths before extraction by checking for `..` components and absolute paths. Consider using `zipfile.Path` or manually iterating members and checking `os.path.commonpath()` before extracting each one. Alternatively, perform long path conversion on the final resolved path rather than on the target directory prefix.

## Changes

- `ai_diffusion/platform_tools.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
