### PR TITLE
Security: Potential arbitrary file read via unsanitized language identifier

### DIFF
--- a/ai_diffusion/localization.py
+++ b/ai_diffusion/localization.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 from typing import NamedTuple
 
@@ -71,6 +72,9 @@ class Localization:
                     language = settings.get("language", "en")
             except Exception as e:
                 log.warning(f"Could not read language settings: {e}")
+
+        if not isinstance(language, str) or not re.fullmatch(r"[a-z]{2}(?:[_-][A-Za-z0-9]+)?", language):
+            language = "en"
 
         language_file = Path(__file__).parent / "language" / f"{language}.json"
         try:


### PR DESCRIPTION
## Summary

Security: Potential arbitrary file read via unsanitized language identifier

## Problem

**Severity**: `Low` | **File**: `ai_diffusion/localization.py:L72`

`language` is read from a settings file and directly interpolated into a filename (`f"{language}.json"`) under the language directory. Values like `../../somefile` may traverse directories and cause unintended file reads if the target is valid JSON with expected keys.

## Solution

Validate `language` against a strict allowlist/pattern (e.g., `^[a-z]{2}([_-][A-Za-z0-9]+)?$`) and/or resolve the final path and enforce it stays within the language directory before opening.

## Changes

- `ai_diffusion/localization.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced