### PR TITLE
<feature request> automatically change float docker to a window

### DIFF
--- a/ai_diffusion/extension.py
+++ b/ai_diffusion/extension.py
@@ -49,8 +49,8 @@ class AIToolsExtension(Extension):
         notifier = Krita.instance().notifier()
         notifier.setActive(True)
         notifier.applicationClosing.connect(self.shutdown)  # type: ignore
-        notifier.viewCreated.connect(lambda: ImageDiffusionDocker.resetDockerStatus('initialize'))  # type: ignore
-        notifier.imageClosed.connect(lambda: ImageDiffusionDocker.resetDockerStatus('imageClosed'))  # type: ignore
+        notifier.viewCreated.connect(lambda: ImageDiffusionDocker.resetDockerStatus("initialize"))  # type: ignore
+        notifier.imageClosed.connect(lambda: ImageDiffusionDocker.resetDockerStatus("imageClosed"))  # type: ignore
 
     def setup(self):
         eventloop.run(root.autostart(self._settings_dialog.connection.update_ui))

--- a/ai_diffusion/extension.py
+++ b/ai_diffusion/extension.py
@@ -10,7 +10,7 @@ from .model import Workspace
 from .root import root
 from .settings import settings
 from .ui import actions
-from .ui.diffusion import ImageDiffusionWidget
+from .ui.diffusion import ImageDiffusionDocker
 from .ui.settings import SettingsDialog
 from .util import client_logger as log
 
@@ -49,6 +49,7 @@ class AIToolsExtension(Extension):
         notifier = Krita.instance().notifier()
         notifier.setActive(True)
         notifier.applicationClosing.connect(self.shutdown)  # type: ignore
+        notifier.viewCreated.connect(ImageDiffusionDocker.setFirstAfterStart)
 
     def setup(self):
         eventloop.run(root.autostart(self._settings_dialog.connection.update_ui))
@@ -88,5 +89,5 @@ class AIToolsExtension(Extension):
 
 Krita.instance().addExtension(AIToolsExtension(Krita.instance()))
 Krita.instance().addDockWidgetFactory(
-    DockWidgetFactory("imageDiffusion", DockWidgetFactoryBase.DockRight, ImageDiffusionWidget)  # type: ignore
+    DockWidgetFactory("imageDiffusion", DockWidgetFactoryBase.DockRight, ImageDiffusionDocker)  # type: ignore
 )

--- a/ai_diffusion/extension.py
+++ b/ai_diffusion/extension.py
@@ -49,8 +49,8 @@ class AIToolsExtension(Extension):
         notifier = Krita.instance().notifier()
         notifier.setActive(True)
         notifier.applicationClosing.connect(self.shutdown)  # type: ignore
-        notifier.viewCreated.connect(lambda : ImageDiffusionDocker.resetDockerStatus('initialize'))
-        notifier.imageClosed.connect(lambda : ImageDiffusionDocker.resetDockerStatus('imageClosed'))
+        notifier.viewCreated.connect(lambda: ImageDiffusionDocker.resetDockerStatus('initialize'))  # type: ignore
+        notifier.imageClosed.connect(lambda: ImageDiffusionDocker.resetDockerStatus('imageClosed'))  # type: ignore
 
     def setup(self):
         eventloop.run(root.autostart(self._settings_dialog.connection.update_ui))

--- a/ai_diffusion/extension.py
+++ b/ai_diffusion/extension.py
@@ -49,7 +49,8 @@ class AIToolsExtension(Extension):
         notifier = Krita.instance().notifier()
         notifier.setActive(True)
         notifier.applicationClosing.connect(self.shutdown)  # type: ignore
-        notifier.viewCreated.connect(ImageDiffusionDocker.setFirstAfterStart)
+        notifier.viewCreated.connect(lambda : ImageDiffusionDocker.resetDockerStatus('initialize'))
+        notifier.imageClosed.connect(lambda : ImageDiffusionDocker.resetDockerStatus('imageClosed'))
 
     def setup(self):
         eventloop.run(root.autostart(self._settings_dialog.connection.update_ui))

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -15,6 +15,11 @@ from .util import client_logger as log
 from .util import encode_json, read_json_with_comments, user_data_dir
 
 
+class LastDockerStatus(Enum):
+    hide = 0
+    docker = 1
+    dialog = 2
+
 class ServerMode(Enum):
     undefined = -1
     managed = 0
@@ -497,6 +502,9 @@ class Settings(QObject):
 
     last_news: str
     _last_news = Setting("Last seen news digest", "")
+
+    last_docker_status: LastDockerStatus
+    _last_docker_status = Setting("Last status of plugin docker", LastDockerStatus.hide)
 
     # Folder where intermediate images are stored for debug purposes (default: None)
     debug_image_folder = os.environ.get("KRITA_AI_DIFFUSION_DEBUG_IMAGE")

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -20,6 +20,7 @@ class LastDockerStatus(Enum):
     docker = 1
     dialog = 2
 
+
 class ServerMode(Enum):
     undefined = -1
     managed = 0

--- a/ai_diffusion/ui/diffusion.py
+++ b/ai_diffusion/ui/diffusion.py
@@ -277,8 +277,9 @@ class WelcomeWidget(QWidget):
 
 class ImageDiffusionDialog(QMainWindow):
     signal_closed = pyqtSignal()
+
     def __init__(self, parent=None):
-        super().__init__(parent) 
+        super().__init__(parent)
         self.setWindowTitle(_("AI Image Generation"))
 
     def updateWindowTitle(self):
@@ -287,7 +288,9 @@ class ImageDiffusionDialog(QMainWindow):
             if self.parentWidget().windowTitle().__len__() == 0:  # type: ignore
                 self.setWindowTitle(_("AI Image Generation"))
             else:
-                self.setWindowTitle(self.parentWidget().windowTitle() + ' - ' + _("AI Image Generation"))  # type: ignore
+                self.setWindowTitle(
+                    self.parentWidget().windowTitle() + " - " + _("AI Image Generation")  # type: ignore
+                )
 
     def closeEvent(self, a0: QCloseEvent | None):
         self.signal_closed.emit()
@@ -357,6 +360,7 @@ class ImageDiffusionWidget(QWidget):
 class ImageDiffusionDocker(DockWidget):
     signal_leaveFloating = pyqtSignal()
     signal_manualOpenDocker = pyqtSignal()
+
     def __init__(self):
         super().__init__()
         self.setWindowTitle(_("AI Image Generation"))
@@ -367,17 +371,23 @@ class ImageDiffusionDocker(DockWidget):
         self._centralWidget = ImageDiffusionWidget()
         self.mutex = QMutex()
         # Status route: modeAllHide <--> modeDocker <--> modeDialog
-        self._floatModeDialog.signal_closed.connect(lambda: self.applyDockerMode('dialog.signal_closed'))
-        self.signal_leaveFloating.connect(lambda: self.applyDialogMode('docker.signal_leaveFloating'))
-        self.signal_manualOpenDocker.connect(lambda: self.applyDockerMode('docker.signal_manualOpenDocker'))
+        self._floatModeDialog.signal_closed.connect(
+            lambda: self.applyDockerMode("dialog.signal_closed")
+        )
+        self.signal_leaveFloating.connect(
+            lambda: self.applyDialogMode("docker.signal_leaveFloating")
+        )
+        self.signal_manualOpenDocker.connect(
+            lambda: self.applyDockerMode("docker.signal_manualOpenDocker")
+        )
 
     def canvasChanged(self, canvas: krita.Canvas):
         if canvas is not None and canvas.view() is not None:
             self._centralWidget.update_content()
-        
+
     def showEvent(self, a0: QShowEvent | None) -> None:
-        #print('ImageDiffusionDocker showEvent')
-        #print('    sender= ', self.sender())
+        # print('ImageDiffusionDocker showEvent')
+        # print('    sender= ', self.sender())
         if self.titleBarEventListening == False:
             if isinstance(self.titleBarWidget(), QWidget):
                 self.titleBarWidget().installEventFilter(self)  # type: ignore
@@ -386,7 +396,7 @@ class ImageDiffusionDocker(DockWidget):
             self.signal_manualOpenDocker.emit()
             return super().showEvent(a0)
         # Failed to catch mousePressEvent/mouseReleaseEvent when moving docker
-        # Failed to catch clicked/toggled/pressed/released signal when click the docker float button 
+        # Failed to catch clicked/toggled/pressed/released signal when click the docker float button
         # Use showEvent instead
         if (QGuiApplication.mouseButtons() & Qt.MouseButton.LeftButton) != Qt.MouseButton.NoButton:
             # Do not switch immediately when dragging the docker to move
@@ -404,10 +414,11 @@ class ImageDiffusionDocker(DockWidget):
                     self._floatModeDialog.setParent(self.parentWidget())
                     # Always reset window type after manually setParent
                     self._floatModeDialog.setWindowFlag(Qt.WindowType.Window)
-                    self.parentWidget().windowTitleChanged.connect(self._floatModeDialog.updateWindowTitle)  # type: ignore
+                    self.parentWidget().windowTitleChanged.connect(  # type: ignore
+                        self._floatModeDialog.updateWindowTitle
+                    )
 
         return super().changeEvent(event)
-
 
     def eventFilter(self, a0: QObject | None, a1: QEvent | None) -> bool:
         if a0 is self.titleBarWidget():
@@ -419,27 +430,25 @@ class ImageDiffusionDocker(DockWidget):
 
         return super().eventFilter(a0, a1)
 
-
     @staticmethod
     def resetDockerStatus(senderName=str()):
         # Only retrieve docker instance after the main window was completely created
         try:
             Krita.instance().activeWindow().qwindow()
         except:
-            print('setFirstAfterStart(): main window not created at this moment')
+            print("resetDockerStatus(): main window not created at this moment")
 
         for d in Krita.instance().dockers():
             if d.objectName() == "imageDiffusion":
                 if isinstance(d, ImageDiffusionDocker):
                     if len(Krita.instance().documents()) == 0:
-                        d.applyHideMode('allImageClosed')
+                        d.applyHideMode("allImageClosed")
                     elif settings.last_docker_status == LastDockerStatus.dialog:
                         d.applyDialogMode(senderName)
                     elif settings.last_docker_status == LastDockerStatus.docker:
                         d.applyDockerMode(senderName)
                     else:
                         d.applyHideMode(senderName)
-
 
     def applyHideMode(self, senderName=str()):
         if self.mutex.tryLock() == False:
@@ -449,10 +458,9 @@ class ImageDiffusionDocker(DockWidget):
         self.close()
         self._floatModeDialog.close()
         self.mutex.unlock()
-        if senderName != 'allImageClosed':
+        if senderName != "allImageClosed":
             settings.last_docker_status = LastDockerStatus.hide
             settings.save()
-
 
     def applyDockerMode(self, senderName=str()):
         if self.mutex.tryLock() == False:
@@ -465,7 +473,6 @@ class ImageDiffusionDocker(DockWidget):
         settings.last_docker_status = LastDockerStatus.docker
         settings.save()
 
-
     def applyDialogMode(self, senderName=str()):
         if self.mutex.tryLock() == False:
             return
@@ -473,21 +480,23 @@ class ImageDiffusionDocker(DockWidget):
         self.close()
         self._floatModeDialog.setCentralWidget(self._centralWidget)
         self._floatModeDialog.show()
-        if senderName == 'initialize':
+        if senderName == "initialize":
             if len(Krita.instance().documents()) == 1:
                 self._floatModeDialog.activateWindow()
                 newWidth = self._floatModeDialog.size().width()
                 newPoint = QCursor.pos()
-                newPoint.setX(newPoint.x()-int(newWidth/2))
-                self._floatModeDialog.move(self._floatModeDialog.mapFrom(self._floatModeDialog, newPoint))
-        elif senderName != 'imageClosed':
+                newPoint.setX(newPoint.x() - int(newWidth / 2))
+                self._floatModeDialog.move(
+                    self._floatModeDialog.mapFrom(self._floatModeDialog, newPoint)
+                )
+        elif senderName != "imageClosed":
             self._floatModeDialog.activateWindow()
             newWidth = self._floatModeDialog.size().width()
             newPoint = QCursor.pos()
-            newPoint.setX(newPoint.x()-int(newWidth/2))
-            self._floatModeDialog.move(self._floatModeDialog.mapFrom(self._floatModeDialog, newPoint))
+            newPoint.setX(newPoint.x() - int(newWidth / 2))
+            self._floatModeDialog.move(
+                self._floatModeDialog.mapFrom(self._floatModeDialog, newPoint)
+            )
         self.mutex.unlock()
         settings.last_docker_status = LastDockerStatus.dialog
         settings.save()
-
-

--- a/ai_diffusion/ui/diffusion.py
+++ b/ai_diffusion/ui/diffusion.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import krita
-from krita import *
 from krita import DockWidget, Krita
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import Qt, pyqtSignal, QEvent, QMutex, QObject
+from PyQt5.QtGui import QCursor, QGuiApplication, QCloseEvent, QShowEvent
 from PyQt5.QtWidgets import (
+    QAction,
     QCheckBox,
     QHBoxLayout,
     QLabel,
+    QMainWindow,
     QPushButton,
     QStackedWidget,
     QVBoxLayout,
@@ -287,7 +289,7 @@ class ImageDiffusionDialog(QMainWindow):
             else:
                 self.setWindowTitle(self.parentWidget().windowTitle() + ' - ' + _("AI Image Generation"))
 
-    def closeEvent(self, event: QtGui.QCloseEvent):
+    def closeEvent(self, event: QCloseEvent):
         self.signal_closed.emit()
         return super().closeEvent(event)
 
@@ -373,7 +375,7 @@ class ImageDiffusionDocker(DockWidget):
         if canvas is not None and canvas.view() is not None:
             self._centralWidget.update_content()
         
-    def showEvent(self, event: QtGui.QShowEvent) -> None:
+    def showEvent(self, event: QShowEvent) -> None:
         #print('PluginDevToolsDocker showEvent')
         #print('    sender= ', self.sender())
         if self.titleBarEventListening == False:
@@ -395,7 +397,7 @@ class ImageDiffusionDocker(DockWidget):
             self.signal_leaveFloating.emit()
         return super().showEvent(event)
 
-    def changeEvent(self, event: QtCore.QEvent) -> None:
+    def changeEvent(self, event: QEvent) -> None:
         if event.type() == QEvent.Type.ParentChange:
             if isinstance(self.parentWidget(), QWidget):
                 self._floatModeDialog.setParent(self.parentWidget())

--- a/ai_diffusion/ui/diffusion.py
+++ b/ai_diffusion/ui/diffusion.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import krita
+from krita import *
 from krita import DockWidget, Krita
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
@@ -18,7 +19,7 @@ from ..localization import translate as _
 from ..model import Model, Workspace
 from ..root import root
 from ..server import Server, ServerState
-from ..settings import ServerMode, settings
+from ..settings import LastDockerStatus, ServerMode, settings
 from ..updates import UpdateState
 from . import theme
 from .animation import AnimationWidget
@@ -272,10 +273,28 @@ class WelcomeWidget(QWidget):
         return self._news_widget.has_news
 
 
-class ImageDiffusionWidget(DockWidget):
+class ImageDiffusionDialog(QMainWindow):
+    signal_closed = pyqtSignal()
+    def __init__(self, parent=None):
+        super().__init__(parent) 
+        self.setWindowTitle(_("AI Image Generation"))
+
+    def updateWindowTitle(self):
+        if isinstance(self.parentWidget(), QWidget):
+            self.setObjectName("ImageDiffusionDialog_" + self.parentWidget().objectName())
+            if self.parentWidget().windowTitle().__len__() == 0:
+                self.setWindowTitle(_("AI Image Generation"))
+            else:
+                self.setWindowTitle(self.parentWidget().windowTitle() + ' - ' + _("AI Image Generation"))
+
+    def closeEvent(self, event: QtGui.QCloseEvent):
+        self.signal_closed.emit()
+        return super().closeEvent(event)
+
+
+class ImageDiffusionWidget(QWidget):
     def __init__(self):
         super().__init__()
-        self.setWindowTitle(_("AI Image Generation"))
         self._welcome = WelcomeWidget(root.server)
         self._generation = GenerationWidget()
         self._upscaling = UpscaleWidget()
@@ -291,16 +310,14 @@ class ImageDiffusionWidget(DockWidget):
         self._frame.addWidget(self._animation)
         self._frame.addWidget(self._custom)
         self._frame.addWidget(self._custom_placeholder)
-        self.setWidget(self._frame)
+        self._layout = QVBoxLayout()
+        self.setLayout(self._layout)
+        self._layout.addWidget(self._frame)
 
         self._welcome.accepted.connect(self.update_content)
         root.connection.state_changed.connect(self.update_content)
         root.auto_update.state_changed.connect(self.update_content)
         root.model_created.connect(self.register_model)
-
-    def canvasChanged(self, canvas: krita.Canvas):
-        if canvas is not None and canvas.view() is not None:
-            self.update_content()
 
     def register_model(self, model: Model):
         model.workspace_changed.connect(self.update_content)
@@ -333,3 +350,129 @@ class ImageDiffusionWidget(DockWidget):
         elif model.workspace is Workspace.custom:
             self._custom.model = model
             self._frame.setCurrentWidget(self._custom)
+
+
+class ImageDiffusionDocker(DockWidget):
+    signal_leaveFloating = pyqtSignal()
+    signal_manualOpenDocker = pyqtSignal()
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle(_("AI Image Generation"))
+        self.titleBarEventListening = False
+        # Prepare a standalone window
+        self._floatModeDialog = ImageDiffusionDialog(self.parent())
+        # Prepare content widget. This widget will be added into docker itself or self._floatModeDialog. Only keep one instance.
+        self._centralWidget = ImageDiffusionWidget()
+        self.mutex = QMutex()
+        # Status route: modeAllHide <--> modeDocker <--> modeDialog
+        self._floatModeDialog.signal_closed.connect(lambda : self.applyDockerMode('dialog.signal_closed'))
+        self.signal_leaveFloating.connect(lambda : self.applyDialogMode('docker.signal_leaveFloating'))
+        self.signal_manualOpenDocker.connect(lambda : self.applyDockerMode('docker.signal_manualOpenDocker'))
+
+    def canvasChanged(self, canvas: krita.Canvas):
+        if canvas is not None and canvas.view() is not None:
+            self._centralWidget.update_content()
+        
+    def showEvent(self, event: QtGui.QShowEvent) -> None:
+        #print('PluginDevToolsDocker showEvent')
+        #print('    sender= ', self.sender())
+        if self.titleBarEventListening == False:
+            if isinstance(self.titleBarWidget(), QWidget):
+                self.titleBarWidget().installEventFilter(self)
+
+        if isinstance(self.sender(), QAction):
+            self.signal_manualOpenDocker.emit()
+            return super().showEvent(event)
+        # Failed to catch mousePressEvent/mouseReleaseEvent when moving docker
+        # Failed to catch clicked/toggled/pressed/released signal when click the docker float button 
+        # Use showEvent instead
+        if (QGuiApplication.mouseButtons() & Qt.MouseButton.LeftButton):
+            # Do not switch immediately when dragging the docker to move
+            return super().showEvent(event)
+
+        # LeftButton is released and the docker is not docked
+        if self.isFloating():
+            self.signal_leaveFloating.emit()
+        return super().showEvent(event)
+
+    def changeEvent(self, event: QtCore.QEvent) -> None:
+        if event.type() == QEvent.Type.ParentChange:
+            if isinstance(self.parentWidget(), QWidget):
+                self._floatModeDialog.setParent(self.parentWidget())
+                # Always reset window type after manually setParent
+                self._floatModeDialog.setWindowFlag(Qt.WindowType.Window)
+                self.parentWidget().windowTitleChanged.connect(self._floatModeDialog.updateWindowTitle)
+
+        return super().changeEvent(event)
+
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+        if obj is self.titleBarWidget():
+            if event.type() == QEvent.Type.MouseButtonDblClick:
+                if not self.isFloating():
+                    self.signal_leaveFloating.emit()
+                    return True
+
+        return super().eventFilter(obj, event)
+
+
+    @staticmethod
+    def setFirstAfterStart():
+        # Only retrieve docker instance after the main window was completely created
+        try:
+            Krita.instance().activeWindow().qwindow()
+        except:
+            print('setFirstAfterStart(): main window not created at this moment')
+
+        for d in Krita.instance().dockers():
+            if d.objectName() == "imageDiffusion":
+                if isinstance(d, ImageDiffusionDocker):
+                    if settings.last_docker_status == LastDockerStatus.dialog:
+                        d.applyDialogMode('initialize')
+                    elif settings.last_docker_status == LastDockerStatus.docker:
+                        d.applyDockerMode('initialize')
+                    else:
+                        d.applyDockerMode('initialize')
+
+
+    def applyHideMode(self, senderName=str()):
+        if self.mutex.tryLock() == False:
+            return
+        self.setFloating(False)
+        self.setWidget(self._centralWidget)
+        self.close()
+        self._floatModeDialog.close()
+        self.mutex.unlock()
+        settings.last_docker_status = LastDockerStatus.hide
+        settings.save()
+
+
+    def applyDockerMode(self, senderName=str()):
+        if self.mutex.tryLock() == False:
+            return
+        self.setFloating(False)
+        self.setWidget(self._centralWidget)
+        self.show()
+        self._floatModeDialog.close()
+        self.mutex.unlock()
+        settings.last_docker_status = LastDockerStatus.docker
+        settings.save()
+
+
+    def applyDialogMode(self, senderName=str()):
+        if self.mutex.tryLock() == False:
+            return
+        self.setFloating(False)
+        self.close()
+        self._floatModeDialog.setCentralWidget(self._centralWidget)
+        self._floatModeDialog.show()
+        self._floatModeDialog.activateWindow()
+        newWidth = self._floatModeDialog.size().width()
+        newPoint = QCursor.pos()
+        newPoint.setX(newPoint.x()-int(newWidth/2))
+        self._floatModeDialog.move(self._floatModeDialog.mapFrom(self._floatModeDialog, newPoint))
+        self.mutex.unlock()
+        settings.last_docker_status = LastDockerStatus.dialog
+        settings.save()
+
+

--- a/ai_diffusion/ui/diffusion.py
+++ b/ai_diffusion/ui/diffusion.py
@@ -445,7 +445,7 @@ class ImageDiffusionDocker(DockWidget):
         for d in Krita.instance().dockers():
             if d.objectName() == "imageDiffusion":
                 if isinstance(d, ImageDiffusionDocker):
-                    if len(Krita.instance().documents()) == 0:
+                    if len(Krita.instance().activeWindow().views()) == 0:
                         d.applyHideMode("allImageClosed")
                     elif settings.last_docker_status == LastDockerStatus.dialog:
                         d.applyDialogMode(senderName)
@@ -483,17 +483,9 @@ class ImageDiffusionDocker(DockWidget):
         self.setFloating(False)
         self.close()
         self._floatModeDialog.setCentralWidget(self._centralWidget)
+        _isVisibleBefore = self._floatModeDialog.isVisible()
         self._floatModeDialog.show()
-        if senderName == "initialize":
-            if len(Krita.instance().documents()) == 1:
-                self._floatModeDialog.activateWindow()
-                newWidth = self._floatModeDialog.size().width()
-                newPoint = QCursor.pos()
-                newPoint.setX(newPoint.x() - int(newWidth / 2))
-                self._floatModeDialog.move(
-                    self._floatModeDialog.mapFrom(self._floatModeDialog, newPoint)
-                )
-        elif senderName != "imageClosed":
+        if not _isVisibleBefore:
             self._floatModeDialog.activateWindow()
             newWidth = self._floatModeDialog.size().width()
             newPoint = QCursor.pos()

--- a/ai_diffusion/ui/diffusion.py
+++ b/ai_diffusion/ui/diffusion.py
@@ -407,6 +407,10 @@ class ImageDiffusionDocker(DockWidget):
             self.signal_leaveFloating.emit()
         return super().showEvent(a0)
 
+    def closeEvent(self, event: QCloseEvent | None):
+        self.applyHideMode()
+        return super().closeEvent(event)
+
     def changeEvent(self, event: QEvent | None) -> None:
         if isinstance(event, QEvent):
             if event.type() == QEvent.Type.ParentChange:

--- a/ai_diffusion/ui/diffusion.py
+++ b/ai_diffusion/ui/diffusion.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import krita
 from krita import DockWidget, Krita
-from PyQt5.QtCore import Qt, pyqtSignal, QEvent, QMutex, QObject
-from PyQt5.QtGui import QCursor, QGuiApplication, QCloseEvent, QShowEvent
+from PyQt5.QtCore import QEvent, QMutex, QObject, Qt, pyqtSignal
+from PyQt5.QtGui import QCloseEvent, QCursor, QGuiApplication, QShowEvent
 from PyQt5.QtWidgets import (
     QAction,
     QCheckBox,
@@ -431,11 +431,11 @@ class ImageDiffusionDocker(DockWidget):
         return super().eventFilter(a0, a1)
 
     @staticmethod
-    def resetDockerStatus(senderName=str()):
+    def resetDockerStatus(senderName=""):
         # Only retrieve docker instance after the main window was completely created
         try:
             Krita.instance().activeWindow().qwindow()
-        except:
+        except AttributeError:
             print("resetDockerStatus(): main window not created at this moment")
 
         for d in Krita.instance().dockers():
@@ -450,7 +450,7 @@ class ImageDiffusionDocker(DockWidget):
                     else:
                         d.applyHideMode(senderName)
 
-    def applyHideMode(self, senderName=str()):
+    def applyHideMode(self, senderName=""):
         if self.mutex.tryLock() == False:
             return
         self.setFloating(False)
@@ -462,7 +462,7 @@ class ImageDiffusionDocker(DockWidget):
             settings.last_docker_status = LastDockerStatus.hide
             settings.save()
 
-    def applyDockerMode(self, senderName=str()):
+    def applyDockerMode(self, senderName=""):
         if self.mutex.tryLock() == False:
             return
         self.setFloating(False)
@@ -473,7 +473,7 @@ class ImageDiffusionDocker(DockWidget):
         settings.last_docker_status = LastDockerStatus.docker
         settings.save()
 
-    def applyDialogMode(self, senderName=str()):
+    def applyDialogMode(self, senderName=""):
         if self.mutex.tryLock() == False:
             return
         self.setFloating(False)

--- a/ai_diffusion/ui/diffusion.py
+++ b/ai_diffusion/ui/diffusion.py
@@ -376,7 +376,7 @@ class ImageDiffusionDocker(DockWidget):
             self._centralWidget.update_content()
         
     def showEvent(self, event: QShowEvent) -> None:
-        #print('PluginDevToolsDocker showEvent')
+        #print('ImageDiffusionDocker showEvent')
         #print('    sender= ', self.sender())
         if self.titleBarEventListening == False:
             if isinstance(self.titleBarWidget(), QWidget):
@@ -419,7 +419,7 @@ class ImageDiffusionDocker(DockWidget):
 
 
     @staticmethod
-    def setFirstAfterStart():
+    def resetDockerStatus(senderName=str()):
         # Only retrieve docker instance after the main window was completely created
         try:
             Krita.instance().activeWindow().qwindow()
@@ -429,12 +429,14 @@ class ImageDiffusionDocker(DockWidget):
         for d in Krita.instance().dockers():
             if d.objectName() == "imageDiffusion":
                 if isinstance(d, ImageDiffusionDocker):
-                    if settings.last_docker_status == LastDockerStatus.dialog:
-                        d.applyDialogMode('initialize')
+                    if len(Krita.instance().documents()) == 0:
+                        d.applyHideMode('allImageClosed')
+                    elif settings.last_docker_status == LastDockerStatus.dialog:
+                        d.applyDialogMode(senderName)
                     elif settings.last_docker_status == LastDockerStatus.docker:
-                        d.applyDockerMode('initialize')
+                        d.applyDockerMode(senderName)
                     else:
-                        d.applyDockerMode('initialize')
+                        d.applyHideMode(senderName)
 
 
     def applyHideMode(self, senderName=str()):
@@ -445,8 +447,9 @@ class ImageDiffusionDocker(DockWidget):
         self.close()
         self._floatModeDialog.close()
         self.mutex.unlock()
-        settings.last_docker_status = LastDockerStatus.hide
-        settings.save()
+        if senderName != 'allImageClosed':
+            settings.last_docker_status = LastDockerStatus.hide
+            settings.save()
 
 
     def applyDockerMode(self, senderName=str()):
@@ -468,11 +471,19 @@ class ImageDiffusionDocker(DockWidget):
         self.close()
         self._floatModeDialog.setCentralWidget(self._centralWidget)
         self._floatModeDialog.show()
-        self._floatModeDialog.activateWindow()
-        newWidth = self._floatModeDialog.size().width()
-        newPoint = QCursor.pos()
-        newPoint.setX(newPoint.x()-int(newWidth/2))
-        self._floatModeDialog.move(self._floatModeDialog.mapFrom(self._floatModeDialog, newPoint))
+        if senderName == 'initialize':
+            if len(Krita.instance().documents()) == 1:
+                self._floatModeDialog.activateWindow()
+                newWidth = self._floatModeDialog.size().width()
+                newPoint = QCursor.pos()
+                newPoint.setX(newPoint.x()-int(newWidth/2))
+                self._floatModeDialog.move(self._floatModeDialog.mapFrom(self._floatModeDialog, newPoint))
+        elif senderName != 'imageClosed':
+            self._floatModeDialog.activateWindow()
+            newWidth = self._floatModeDialog.size().width()
+            newPoint = QCursor.pos()
+            newPoint.setX(newPoint.x()-int(newWidth/2))
+            self._floatModeDialog.move(self._floatModeDialog.mapFrom(self._floatModeDialog, newPoint))
         self.mutex.unlock()
         settings.last_docker_status = LastDockerStatus.dialog
         settings.save()

--- a/ai_diffusion/ui/diffusion.py
+++ b/ai_diffusion/ui/diffusion.py
@@ -283,15 +283,15 @@ class ImageDiffusionDialog(QMainWindow):
 
     def updateWindowTitle(self):
         if isinstance(self.parentWidget(), QWidget):
-            self.setObjectName("ImageDiffusionDialog_" + self.parentWidget().objectName())
-            if self.parentWidget().windowTitle().__len__() == 0:
+            self.setObjectName("ImageDiffusionDialog_" + self.parentWidget().objectName())  # type: ignore
+            if self.parentWidget().windowTitle().__len__() == 0:  # type: ignore
                 self.setWindowTitle(_("AI Image Generation"))
             else:
-                self.setWindowTitle(self.parentWidget().windowTitle() + ' - ' + _("AI Image Generation"))
+                self.setWindowTitle(self.parentWidget().windowTitle() + ' - ' + _("AI Image Generation"))  # type: ignore
 
-    def closeEvent(self, event: QCloseEvent):
+    def closeEvent(self, a0: QCloseEvent | None):
         self.signal_closed.emit()
-        return super().closeEvent(event)
+        return super().closeEvent(a0)
 
 
 class ImageDiffusionWidget(QWidget):
@@ -367,55 +367,57 @@ class ImageDiffusionDocker(DockWidget):
         self._centralWidget = ImageDiffusionWidget()
         self.mutex = QMutex()
         # Status route: modeAllHide <--> modeDocker <--> modeDialog
-        self._floatModeDialog.signal_closed.connect(lambda : self.applyDockerMode('dialog.signal_closed'))
-        self.signal_leaveFloating.connect(lambda : self.applyDialogMode('docker.signal_leaveFloating'))
-        self.signal_manualOpenDocker.connect(lambda : self.applyDockerMode('docker.signal_manualOpenDocker'))
+        self._floatModeDialog.signal_closed.connect(lambda: self.applyDockerMode('dialog.signal_closed'))
+        self.signal_leaveFloating.connect(lambda: self.applyDialogMode('docker.signal_leaveFloating'))
+        self.signal_manualOpenDocker.connect(lambda: self.applyDockerMode('docker.signal_manualOpenDocker'))
 
     def canvasChanged(self, canvas: krita.Canvas):
         if canvas is not None and canvas.view() is not None:
             self._centralWidget.update_content()
         
-    def showEvent(self, event: QShowEvent) -> None:
+    def showEvent(self, a0: QShowEvent | None) -> None:
         #print('ImageDiffusionDocker showEvent')
         #print('    sender= ', self.sender())
         if self.titleBarEventListening == False:
             if isinstance(self.titleBarWidget(), QWidget):
-                self.titleBarWidget().installEventFilter(self)
+                self.titleBarWidget().installEventFilter(self)  # type: ignore
 
         if isinstance(self.sender(), QAction):
             self.signal_manualOpenDocker.emit()
-            return super().showEvent(event)
+            return super().showEvent(a0)
         # Failed to catch mousePressEvent/mouseReleaseEvent when moving docker
         # Failed to catch clicked/toggled/pressed/released signal when click the docker float button 
         # Use showEvent instead
-        if (QGuiApplication.mouseButtons() & Qt.MouseButton.LeftButton):
+        if (QGuiApplication.mouseButtons() & Qt.MouseButton.LeftButton) != Qt.MouseButton.NoButton:
             # Do not switch immediately when dragging the docker to move
-            return super().showEvent(event)
+            return super().showEvent(a0)
 
         # LeftButton is released and the docker is not docked
         if self.isFloating():
             self.signal_leaveFloating.emit()
-        return super().showEvent(event)
+        return super().showEvent(a0)
 
-    def changeEvent(self, event: QEvent) -> None:
-        if event.type() == QEvent.Type.ParentChange:
-            if isinstance(self.parentWidget(), QWidget):
-                self._floatModeDialog.setParent(self.parentWidget())
-                # Always reset window type after manually setParent
-                self._floatModeDialog.setWindowFlag(Qt.WindowType.Window)
-                self.parentWidget().windowTitleChanged.connect(self._floatModeDialog.updateWindowTitle)
+    def changeEvent(self, event: QEvent | None) -> None:
+        if isinstance(event, QEvent):
+            if event.type() == QEvent.Type.ParentChange:
+                if isinstance(self.parentWidget(), QWidget):
+                    self._floatModeDialog.setParent(self.parentWidget())
+                    # Always reset window type after manually setParent
+                    self._floatModeDialog.setWindowFlag(Qt.WindowType.Window)
+                    self.parentWidget().windowTitleChanged.connect(self._floatModeDialog.updateWindowTitle)  # type: ignore
 
         return super().changeEvent(event)
 
 
-    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
-        if obj is self.titleBarWidget():
-            if event.type() == QEvent.Type.MouseButtonDblClick:
-                if not self.isFloating():
-                    self.signal_leaveFloating.emit()
-                    return True
+    def eventFilter(self, a0: QObject | None, a1: QEvent | None) -> bool:
+        if a0 is self.titleBarWidget():
+            if isinstance(a1, QEvent):
+                if a1.type() == QEvent.Type.MouseButtonDblClick:
+                    if not self.isFloating():
+                        self.signal_leaveFloating.emit()
+                        return True
 
-        return super().eventFilter(obj, event)
+        return super().eventFilter(a0, a1)
 
 
     @staticmethod


### PR DESCRIPTION

https://github.com/user-attachments/assets/55bd7b8f-3425-477e-b1e3-260b4c44a859

## Why is necessary
The docker takes too much space. Even though user can make the docker float, the docker always keep above on the main window.
After change the float docker to a window, user can easily use system shortcuts (Win+Up, Win+Down, Alt+Tab, etc...) to minimize/maximize/switch the windows. It is useful to users who only have one small monitor.

## How to change the docker into a window
(1) Double click titlebar of the docker.
(2) Click float button of the docker.
(3) Drag the docker to non-docker-area then release.


## How to change the window back to docker
Just simply close the extension window (Alt+F4, or click the close button), then it will change back to docker.


## How to move the docker to other position
(If it is under window mode, change back to docker mode first.) Drag the docker to other docker-area then release.