### PR TITLE
Add ERNIE Image architecture support

### DIFF
--- a/ai_diffusion/comfy_client.py
+++ b/ai_diffusion/comfy_client.py
@@ -751,7 +751,7 @@ def _find_text_encoder_models(model_list: Sequence[str]):
     kind = ResourceKind.text_encoder
     return {
         resource_id(kind, Arch.all, te): _find_model(model_list, kind, Arch.all, te)
-        for te in ["clip_l", "clip_g", "t5", "qwen", "qwen_3_06b", "qwen_3_4b", "qwen_3_8b"]
+        for te in ["clip_l", "clip_g", "t5", "qwen", "qwen_3_06b", "qwen_3_4b", "qwen_3_8b", "ministral"]
     }
 
 

--- a/ai_diffusion/comfy_workflow.py
+++ b/ai_diffusion/comfy_workflow.py
@@ -613,7 +613,7 @@ class ComfyWorkflow:
         w, h = extent.width, extent.height
         if arch.is_flux_like or arch.is_qwen_like or arch in (Arch.sd3, Arch.chroma, Arch.zimage):
             return self.add("EmptySD3LatentImage", 1, width=w, height=h, batch_size=batch_size)
-        if arch.is_flux2:
+        if arch.is_flux2 or arch is Arch.ernie:
             return self.add("EmptyFlux2LatentImage", 1, width=w, height=h, batch_size=batch_size)
         else:
             return self.add("EmptyLatentImage", 1, width=w, height=h, batch_size=batch_size)

--- a/ai_diffusion/icons/sd-version-ernie-dark.svg
+++ b/ai_diffusion/icons/sd-version-ernie-dark.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 135.46667 135.46667" version="1.1">
+  <g>
+    <rect style="fill:#c8c8c8;fill-opacity:1" width="132.29167" height="90.132782" x="1.7008928" y="25.527931" rx="21.166666" ry="24.035408" />
+    <rect style="fill:#3d3d3d;fill-opacity:1" x="40" y="38" width="14" height="60" />
+    <rect style="fill:#3d3d3d;fill-opacity:1" x="40" y="38" width="52" height="13" />
+    <rect style="fill:#3d3d3d;fill-opacity:1" x="40" y="62" width="43" height="12" />
+    <rect style="fill:#3d3d3d;fill-opacity:1" x="40" y="85" width="52" height="13" />
+  </g>
+</svg>

--- a/ai_diffusion/icons/sd-version-ernie-light.svg
+++ b/ai_diffusion/icons/sd-version-ernie-light.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 135.46667 135.46667" version="1.1">
+  <g>
+    <rect style="fill:#3d3d3d;fill-opacity:1" width="132.29167" height="90.132782" x="1.7008928" y="25.527931" rx="21.166666" ry="24.035408" />
+    <rect style="fill:#c8c8c8;fill-opacity:1" x="40" y="38" width="14" height="60" />
+    <rect style="fill:#c8c8c8;fill-opacity:1" x="40" y="38" width="52" height="13" />
+    <rect style="fill:#c8c8c8;fill-opacity:1" x="40" y="62" width="43" height="12" />
+    <rect style="fill:#c8c8c8;fill-opacity:1" x="40" y="85" width="52" height="13" />
+  </g>
+</svg>

--- a/ai_diffusion/resources.py
+++ b/ai_diffusion/resources.py
@@ -97,6 +97,7 @@ class Arch(Enum):
     qwen_l = "Qwen Layered"
     anima = "Anima"
     zimage = "Z-Image"
+    ernie = "ERNIE Image"
 
     auto = "Automatic"
     all = "All"
@@ -139,6 +140,8 @@ class Arch(Enum):
             return Arch.anima
         if string in {"z-image", "zimage"}:
             return Arch.zimage
+        if string in {"ernie-image", "ernie_image"}:
+            return Arch.ernie
         return None
 
     @staticmethod
@@ -244,6 +247,8 @@ class Arch(Enum):
                 return ["qwen_3_06b"]
             case Arch.zimage:
                 return ["qwen_3_4b"]
+            case Arch.ernie:
+                return ["ministral"]
         raise ValueError(f"Unsupported architecture: {self}")
 
     @staticmethod
@@ -265,6 +270,7 @@ class Arch(Enum):
             Arch.qwen_l,
             Arch.anima,
             Arch.zimage,
+            Arch.ernie,
         ]
 
 
@@ -799,6 +805,7 @@ search_paths: dict[str, list[str]] = {
     resource_id(ResourceKind.text_encoder, Arch.all, "qwen_3_4b"): ["qwen_3_4b", "qwen3-4b", "qwen3_4b", "qwen_3", "qwen-3"],
     resource_id(ResourceKind.text_encoder, Arch.all, "qwen_3_8b"): ["qwen_3_8b", "qwen3-8b", "qwen3_8b"],
     resource_id(ResourceKind.text_encoder, Arch.all, "qwen_3_06b"): ["qwen_3_06b", "qwen3-06b", "qwen3_06b"],
+    resource_id(ResourceKind.text_encoder, Arch.all, "ministral"): ["ministral-3-3b", "ministral"],
     resource_id(ResourceKind.vae, Arch.sd15, "default"): ["vae-ft-mse-840000-ema"],
     resource_id(ResourceKind.vae, Arch.sdxl, "default"): ["sdxl_vae"],
     resource_id(ResourceKind.vae, Arch.illu, "default"): ["sdxl_vae"],
@@ -815,6 +822,7 @@ search_paths: dict[str, list[str]] = {
     resource_id(ResourceKind.vae, Arch.qwen_l, "default"): ["qwen_image_layered_vae"],
     resource_id(ResourceKind.vae, Arch.anima, "default"): ["qwen_image"],
     resource_id(ResourceKind.vae, Arch.zimage, "default"): ["z-image", "flux-", "flux_", "flux/", "flux1", "ae.s"],
+    resource_id(ResourceKind.vae, Arch.ernie, "default"): ["flux2"],
 }
 # fmt: on
 
@@ -848,6 +856,8 @@ required_resource_ids = {
     ResourceId(ResourceKind.vae, Arch.zimage, "default"),
     ResourceId(ResourceKind.vae, Arch.flux2_4b, "default"),
     ResourceId(ResourceKind.vae, Arch.flux2_9b, "default"),
+    ResourceId(ResourceKind.text_encoder, Arch.ernie, "ministral"),
+    ResourceId(ResourceKind.vae, Arch.ernie, "default"),
 }
 
 recommended_resource_ids = [

--- a/ai_diffusion/ui/theme.py
+++ b/ai_diffusion/ui/theme.py
@@ -83,6 +83,8 @@ def checkpoint_icon(arch: Arch, format: FileFormat | None = None, client: Client
         return icon("sd-version-z-image")
     elif arch is Arch.anima:
         return icon("sd-version-anima")
+    elif arch is Arch.ernie:
+        return icon("sd-version-ernie")
     else:
         log.warning(f"Unresolved SD version {arch}, cannot fetch icon")
         return icon("warning")

--- a/ai_diffusion/workflow.py
+++ b/ai_diffusion/workflow.py
@@ -167,6 +167,8 @@ def load_checkpoint_with_lora(w: ComfyWorkflow, checkpoint: CheckpointInput, mod
                 clip = w.load_clip(te["qwen_3_06b"], type="omnigen2")
             case Arch.zimage:
                 clip = w.load_clip(te["qwen_3_4b"], type="lumina2")
+            case Arch.ernie:
+                clip = w.load_clip(te["ministral"], type="flux2")
             case _:
                 raise RuntimeError(f"No text encoder for model architecture {arch.name}")
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -54,6 +54,7 @@ def test_resource_ids_exist():
             Arch.qwen_e_p,
             Arch.flux2_9b,
             Arch.anima,
+            Arch.ernie,
         ):
             continue  # no model downloads yet
         model = res.find_resource(resource_id)


### PR DESCRIPTION
Adds support for [ERNIE Image](https://huggingface.co/baidu/ERNIE-Image) by Baidu - a diffusion model using a Ministral-3B text encoder and the Flux 2 VAE.

@Acly, I am sharing this PR as is, based on what I quickly developed for my needs (as I was a bit impatient to wait :D). If it passes initial review, I can spend some time polishing it (items mentioned in Todos).

**Model files:**

- ernie-image.safetensors - base model (CFG-guided)
- ernie-image-turbo.safetensors - distilled variant (CFG=1.0)

**Architecture highlights:**

- Text encoder: Ministral-3-3B (CLIPLoader, type flux2)
- VAE: shared with Flux 2 Klein (flux2-vae.safetensors)
- Latent space: EmptyFlux2LatentImage

Requires a patch to comfyui-tooling-nodes to report base_model: "ernie-image" for ERNIE diffusion models (currently returns "unknown"): https://github.com/Acly/comfyui-tooling-nodes/pull/63

**Preview:**

<img width="1280" height="720" alt="ernie" src="https://github.com/user-attachments/assets/47fcf231-587d-478e-94aa-05ab3abf53b4" />

<img width="1951" height="764" alt="image" src="https://github.com/user-attachments/assets/bc149e6c-183e-4973-bee0-a571b2c48487" />
