### PR TITLE
Preserve style architecture in custom workflows

### DIFF
--- a/ai_diffusion/model/custom_workflow.py
+++ b/ai_diffusion/model/custom_workflow.py
@@ -22,7 +22,14 @@ from PyQt5.QtCore import (
 
 from .. import eventloop
 from ..backend.api import CustomStyleInput, InpaintContext, WorkflowInput
-from ..backend.client import ClientModels, ClientOutput, JobInfoOutput, OutputBatchMode, TextOutput
+from ..backend.client import (
+    ClientModels,
+    ClientOutput,
+    JobInfoOutput,
+    OutputBatchMode,
+    TextOutput,
+    resolve_arch,
+)
 from ..backend.comfy_workflow import ComfyNode, ComfyWorkflow
 from ..backend.workflow import sampling_from_style
 from ..image import Bounds, Image, Mask
@@ -591,8 +598,10 @@ class CustomWorkspace(QObject, ObservableProperties):
                     use_live_sampling = True
                 else:  # auto
                     use_live_sampling = is_live
+                style_models = style.get_models(models.checkpoints)
+                style_models.version = resolve_arch(style, models)
                 params[md.name] = CustomStyleInput(
-                    style.get_models(models.checkpoints),
+                    style_models,
                     sampling_from_style(style, 1.0, use_live_sampling),
                     style.style_prompt,
                     style.negative_prompt,

--- a/tests/test_custom_workflow.py
+++ b/tests/test_custom_workflow.py
@@ -25,6 +25,7 @@ from ai_diffusion.backend.client import (
 from ai_diffusion.backend.comfy_workflow import ComfyNode, ComfyObjectInfo, ComfyWorkflow, Output
 from ai_diffusion.backend.resources import Arch
 from ai_diffusion.image import Bounds, Extent, Image, ImageCollection, Mask
+from ai_diffusion.layer import LayerManager
 from ai_diffusion.model.connection import Connection, ConnectionState
 from ai_diffusion.model.custom_workflow import (
     CustomParam,
@@ -36,7 +37,7 @@ from ai_diffusion.model.custom_workflow import (
     workflow_parameters,
 )
 from ai_diffusion.model.jobs import Job, JobKind, JobParams, JobQueue
-from ai_diffusion.style import Style
+from ai_diffusion.style import Style, Styles
 from ai_diffusion.util import PluginError
 
 from .config import test_dir
@@ -366,6 +367,43 @@ def test_parameters():
         CustomParam(ParamKind.mask_layer, "mask"),
         CustomParam(ParamKind.style, "style", "live"),
     ]
+
+
+def test_collect_parameters_preserves_style_architecture():
+    graph = {
+        "1": {
+            "class_type": "ETN_KritaStyle",
+            "inputs": {"name": "style", "sampler_preset": "auto"},
+        }
+    }
+    connection = create_mock_connection({"connection1": graph})
+    workflows = WorkflowCollection(connection)
+    workspace = CustomWorkspace(workflows, dummy_generate, JobQueue())
+
+    styles = Styles.list()
+    style = styles.create("anima-test.json")
+    try:
+        style.architecture = Arch.anima
+        style.checkpoints = ["checkpoint.safetensors"]
+        workspace.params["style"] = style.filename
+
+        models = ClientModels()
+        models.checkpoints = {
+            "checkpoint.safetensors": CheckpointInfo("checkpoint.safetensors", Arch.anima)
+        }
+
+        params = workspace.collect_parameters(
+            layers=LayerManager(None),
+            bounds=Bounds(0, 0, 1, 1),
+            models=models,
+            is_live=False,
+            is_animation=False,
+        )
+
+        assert isinstance(params["style"], CustomStyleInput)
+        assert params["style"].models.version is Arch.anima
+    finally:
+        styles.delete(style)
 
 
 def test_parameter_order():


### PR DESCRIPTION
## Summary

When using Graph mode with Anima, workflows that include `ETN_KritaStyle` can fail with:

```text
Server error: Text Encoder 'clip_l' for SD 1.5 not found
```

<img width="453" height="431" alt="image" src="https://github.com/user-attachments/assets/18e355f9-19ab-4bc9-bcec-abf490495143" />

<img width="990" height="161" alt="image" src="https://github.com/user-attachments/assets/03147f6f-6483-4659-ae83-ef7ab6f133c4" />

<img width="493" height="286" alt="image" src="https://github.com/user-attachments/assets/f6275c1c-bfc7-4959-beab-220b8b55f54e" />

The style preset may explicitly use the Anima diffusion architecture, but custom workflow parameter collection was passing style.get_models(...) directly into CustomStyleInput. In some cases, especially with
generic checkpoint filenames, that leaves the collected style models at the default SD 1.5 architecture instead of the architecture resolved from the connected model metadata.

As a result, an Anima checkpoint can be routed through the SD 1.5 text encoder path.

This change resolves the style architecture using the available checkpoint metadata before creating CustomStyleInput, so custom workflows preserve the intended architecture such as Anima.
