### PR TITLE
Fix plugin auto-update install layout

### DIFF
--- a/ai_diffusion/model/updates.py
+++ b/ai_diffusion/model/updates.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import shutil
 from enum import Enum
+from itertools import zip_longest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import NamedTuple
@@ -31,6 +32,25 @@ class UpdatePackage(NamedTuple):
     version: str
     url: str
     sha256: str
+
+
+def _version_parts(version: str) -> list[int]:
+    result = []
+    for part in version.split("."):
+        digits = ""
+        for char in part:
+            if not char.isdigit():
+                break
+            digits += char
+        result.append(int(digits or 0))
+    return result
+
+
+def _is_newer_version(version: str, current_version: str) -> bool:
+    for a, b in zip_longest(_version_parts(version), _version_parts(current_version), fillvalue=0):
+        if a != b:
+            return a > b
+    return False
 
 
 class AutoUpdate(QObject, ObservableProperties):
@@ -79,7 +99,7 @@ class AutoUpdate(QObject, ObservableProperties):
             log.error(f"Invalid plugin update information: {result}")
             self.state = UpdateState.failed_check
             self.error = "Failed to retrieve plugin update information"
-        elif self.latest_version == self.current_version:
+        elif not _is_newer_version(self.latest_version, self.current_version):
             log.info("Plugin is up to date!")
             self.state = UpdateState.latest
         elif "url" not in result or "sha256" not in result:
@@ -122,13 +142,31 @@ class AutoUpdate(QObject, ObservableProperties):
             zip_file.extractall(source_dir)
 
         log.info(f"Installing new plugin version to {self.plugin_dir}")
-        shutil.copytree(source_dir, self.plugin_dir, dirs_exist_ok=True)
+        package_plugin_dir = source_dir / "ai_diffusion"
+        if package_plugin_dir.exists():
+            shutil.rmtree(self.plugin_dir / "ai_diffusion", ignore_errors=True)
+            (self.plugin_dir / "ai_diffusion.desktop").unlink(missing_ok=True)
+            shutil.copytree(package_plugin_dir, self.plugin_dir, dirs_exist_ok=True)
+
+            package_desktop = source_dir / "ai_diffusion.desktop"
+            if package_desktop.exists():
+                shutil.copy2(package_desktop, self.plugin_dir.parent / "ai_diffusion.desktop")
+
+            package_action = package_plugin_dir / "ai_diffusion.action"
+            if package_action.exists():
+                actions_dir = self.plugin_dir.parent.parent / "actions"
+                actions_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(package_action, actions_dir / "ai_diffusion.action")
+        else:
+            shutil.copytree(source_dir, self.plugin_dir, dirs_exist_ok=True)
         self.current_version = self.latest_version
         self.state = UpdateState.restart_required
 
     @property
     def is_available(self):
-        return self.latest_version is not None and self.latest_version != self.current_version
+        return bool(self.latest_version) and _is_newer_version(
+            self.latest_version, self.current_version
+        )
 
     @property
     def _net(self):

--- a/ai_diffusion/model/updates.py
+++ b/ai_diffusion/model/updates.py
@@ -90,6 +90,7 @@ class AutoUpdate(QObject, ObservableProperties):
             return
 
         self.state = UpdateState.checking
+        self._package = None
         log.info(f"Checking for latest plugin version at {self.api_url}")
         result = await self._net.get(
             f"{self.api_url}/plugin/latest?version={self.current_version}", timeout=10
@@ -121,21 +122,25 @@ class AutoUpdate(QObject, ObservableProperties):
         )
 
     async def _run(self):
-        assert self.latest_version and self._package
+        if self.state is not UpdateState.available or self._package is None:
+            raise RuntimeError("No plugin update package is available")
+        if self._package.version != self.latest_version:
+            raise RuntimeError("Plugin update package does not match latest version")
+        package = self._package
 
         self._temp_dir = TemporaryDirectory()
-        archive_path = Path(self._temp_dir.name) / f"krita_ai_diffusion-{self.latest_version}.zip"
-        log.info(f"Downloading plugin update {self._package.url}")
+        archive_path = Path(self._temp_dir.name) / f"krita_ai_diffusion-{package.version}.zip"
+        log.info(f"Downloading plugin update {package.url}")
         self.state = UpdateState.downloading
-        archive_data = await self._net.download(self._package.url)
+        archive_data = await self._net.download(package.url)
 
         sha256 = hashlib.sha256(archive_data).hexdigest()
-        if sha256 != self._package.sha256:
-            log.error(f"Update package hash mismatch: {sha256} != {self._package.sha256}")
+        if sha256 != package.sha256:
+            log.error(f"Update package hash mismatch: {sha256} != {package.sha256}")
             raise RuntimeError("Downloaded plugin package is corrupted or incomplete")
 
         archive_path.write_bytes(archive_data)
-        source_dir = Path(self._temp_dir.name) / f"krita_ai_diffusion-{self.latest_version}"
+        source_dir = Path(self._temp_dir.name) / f"krita_ai_diffusion-{package.version}"
         log.info(f"Extracting plugin archive into {source_dir}")
         self.state = UpdateState.installing
         with ZipFile(archive_path) as zip_file:
@@ -143,7 +148,7 @@ class AutoUpdate(QObject, ObservableProperties):
 
         log.info(f"Installing new plugin version to {self.plugin_dir}")
         package_plugin_dir = source_dir / "ai_diffusion"
-        if package_plugin_dir.exists():
+        if package_plugin_dir.is_dir():
             shutil.rmtree(self.plugin_dir / "ai_diffusion", ignore_errors=True)
             (self.plugin_dir / "ai_diffusion.desktop").unlink(missing_ok=True)
             shutil.copytree(package_plugin_dir, self.plugin_dir, dirs_exist_ok=True)

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -7,7 +7,7 @@ import pytest
 from aiohttp import ClientSession
 from PyQt5.QtCore import pyqtBoundSignal
 
-from ai_diffusion.model.updates import AutoUpdate, UpdateState
+from ai_diffusion.model.updates import AutoUpdate, UpdateState, _is_newer_version
 from ai_diffusion.platform_tools import ZipFile
 
 from .conftest import CloudService, qtapp
@@ -43,6 +43,20 @@ def http_session(service_url: str):
     return ClientSession(service_url, headers=headers)
 
 
+@pytest.mark.parametrize(
+    ("version", "current_version", "expected"),
+    [
+        ("1.51.1", "1.51.1", False),
+        ("1.51.0", "1.51.1", False),
+        ("1.52.0", "1.51.9", True),
+        ("1.51.10", "1.51.9", True),
+        ("1.51", "1.51.0", False),
+    ],
+)
+def test_is_newer_version(version: str, current_version: str, expected: bool):
+    assert _is_newer_version(version, current_version) is expected
+
+
 @qtapp
 async def test_update_check_ignores_older_versions(tmp_path: Path):
     updater = AutoUpdate(
@@ -53,18 +67,37 @@ async def test_update_check_ignores_older_versions(tmp_path: Path):
     updater._request_manager = cast(
         Any,
         FakeUpdateService({
-            "version": "1.51.0",
-            "url": "https://example.invalid/krita_ai_diffusion-1.51.0.zip",
+            "version": "1.51.2",
+            "url": "https://example.invalid/krita_ai_diffusion-1.51.2.zip",
             "sha256": "unused",
         }),
     )
 
     state_changes = SignalObserver(updater.state_changed)
     await updater.check()
+    assert updater.state is UpdateState.available
+    assert updater._package is not None
+
+    updater._request_manager = cast(
+        Any,
+        FakeUpdateService({
+            "version": "1.51.0",
+            "url": "https://example.invalid/krita_ai_diffusion-1.51.0.zip",
+            "sha256": "unused",
+        }),
+    )
+
+    state_changes.reset()
+    await updater.check()
 
     assert state_changes.events == [UpdateState.checking, UpdateState.latest]
     assert updater.state is UpdateState.latest
+    assert updater._package is None
     assert not updater.is_available
+
+    await updater.run()
+    assert updater.state is UpdateState.failed_update
+    assert "No plugin update package is available" in updater.error
 
 
 @qtapp
@@ -72,8 +105,10 @@ async def test_update_installs_release_package_layout(tmp_path: Path):
     install_dir = tmp_path / "krita" / "pykrita" / "ai_diffusion"
     install_dir.mkdir(parents=True)
     (install_dir / "test_file.txt").write_text("old plugin")
+    (install_dir / "ai_diffusion").mkdir()
+    (install_dir / "ai_diffusion" / "old_nested_file.txt").write_text("old nested plugin")
+    (install_dir / "ai_diffusion.desktop").write_text("misplaced desktop metadata")
     actions_dir = tmp_path / "krita" / "actions"
-    actions_dir.mkdir()
 
     build_dir = tmp_path / "build"
     build_plugin_dir = build_dir / "ai_diffusion"

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -1,5 +1,7 @@
+import hashlib
 import os
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 from aiohttp import ClientSession
@@ -23,10 +25,97 @@ class SignalObserver:
         self.events = []
 
 
+class FakeUpdateService:
+    def __init__(self, response: dict, archive_data: bytes = b""):
+        self.response = response
+        self.archive_data = archive_data
+
+    async def get(self, url: str, timeout: int = 10):
+        return self.response
+
+    async def download(self, url: str):
+        return self.archive_data
+
+
 def http_session(service_url: str):
     service_token = os.environ["INTERSTICE_INFRA_TOKEN"]
     headers = {"Authorization": f"Bearer {service_token}"}
     return ClientSession(service_url, headers=headers)
+
+
+@qtapp
+async def test_update_check_ignores_older_versions(tmp_path: Path):
+    updater = AutoUpdate(
+        current_version="1.51.1",
+        plugin_dir=tmp_path / "pykrita" / "ai_diffusion",
+        api_url="https://example.invalid",
+    )
+    updater._request_manager = cast(
+        Any,
+        FakeUpdateService({
+            "version": "1.51.0",
+            "url": "https://example.invalid/krita_ai_diffusion-1.51.0.zip",
+            "sha256": "unused",
+        }),
+    )
+
+    state_changes = SignalObserver(updater.state_changed)
+    await updater.check()
+
+    assert state_changes.events == [UpdateState.checking, UpdateState.latest]
+    assert updater.state is UpdateState.latest
+    assert not updater.is_available
+
+
+@qtapp
+async def test_update_installs_release_package_layout(tmp_path: Path):
+    install_dir = tmp_path / "krita" / "pykrita" / "ai_diffusion"
+    install_dir.mkdir(parents=True)
+    (install_dir / "test_file.txt").write_text("old plugin")
+    actions_dir = tmp_path / "krita" / "actions"
+    actions_dir.mkdir()
+
+    build_dir = tmp_path / "build"
+    build_plugin_dir = build_dir / "ai_diffusion"
+    build_plugin_dir.mkdir(parents=True)
+    (build_dir / "ai_diffusion.desktop").write_text("desktop metadata")
+    (build_plugin_dir / "ai_diffusion.action").write_text("action metadata")
+    (build_plugin_dir / "test_file.txt").write_text("new plugin")
+
+    archive_path = build_dir / "krita_ai_diffusion-1.51.2.zip"
+    with ZipFile(archive_path, "w") as zip_file:
+        zip_file.write(build_dir / "ai_diffusion.desktop", "ai_diffusion.desktop")
+        for file in build_plugin_dir.iterdir():
+            zip_file.write(file, f"ai_diffusion/{file.name}")
+    archive_data = archive_path.read_bytes()
+
+    updater = AutoUpdate(
+        current_version="1.51.1",
+        plugin_dir=install_dir,
+        api_url="https://example.invalid",
+    )
+    updater._request_manager = cast(
+        Any,
+        FakeUpdateService(
+            {
+                "version": "1.51.2",
+                "url": "https://example.invalid/krita_ai_diffusion-1.51.2.zip",
+                "sha256": hashlib.sha256(archive_data).hexdigest(),
+            },
+            archive_data,
+        ),
+    )
+
+    await updater.check()
+    assert updater.state is UpdateState.available
+    await updater.run()
+
+    assert updater.state is UpdateState.restart_required
+    assert (install_dir / "test_file.txt").read_text() == "new plugin"
+    assert not (install_dir / "ai_diffusion").exists()
+    assert not (install_dir / "ai_diffusion.desktop").exists()
+    assert (install_dir.parent / "ai_diffusion.desktop").read_text() == "desktop metadata"
+    assert (actions_dir / "ai_diffusion.action").read_text() == "action metadata"
 
 
 @qtapp


### PR DESCRIPTION
## Summary
- Treat older/equal plugin versions from the update API as up-to-date instead of available updates.
- Install release archives using the actual Krita resource layout: copy `ai_diffusion/` into the plugin directory, `ai_diffusion.desktop` into `pykrita/`, and `ai_diffusion.action` into `actions/`.
- Clean up the nested `ai_diffusion/` folder and misplaced `ai_diffusion.desktop` created by the previous updater path.
- Add local regression tests that do not require the cloud update service.

## Motivation
The current updater copies the extracted archive root directly into the installed plugin directory. Release archives contain `ai_diffusion/` and `ai_diffusion.desktop` at their root, so this creates a nested `ai_diffusion/ai_diffusion/` installation and leaves the active plugin files unchanged.

It also treats any version mismatch as an available update. If the update API reports an older compatible version than the installed plugin, the UI keeps showing the update screen and can repeatedly attempt a downgrade.

## Test Plan
- `pytest tests/test_updates.py::test_update_check_ignores_older_versions tests/test_updates.py::test_update_installs_release_package_layout -q`
- `pytest tests/test_updates.py -q`
- `ruff format --check ai_diffusion/model/updates.py tests/test_updates.py`
- `ruff check ai_diffusion/model/updates.py tests/test_updates.py`
- `pyright ai_diffusion/model/updates.py tests/test_updates.py`

I also ran `pytest tests --ci -q`; unrelated environment/setup checks failed locally because `tests/server` is not installed and PyQt5's bundled Qt was built against OpenSSL 1.x while the runtime is OpenSSL 3.x. The new updater tests pass independently.
