### PR TITLE
Iterate seed after apply

### DIFF
--- a/ai_diffusion/backend/workflow.py
+++ b/ai_diffusion/backend/workflow.py
@@ -61,6 +61,8 @@ def generate_seed():
     # Currently only using 32 bit because Qt widgets don't support int64
     return random.randint(0, 2**32 - 1)
 
+def iterate_seed(old_seed):
+    return (old_seed + 1) % (2**32 - 1)
 
 def sampling_from_style(style: Style, strength: float, is_live: bool):
     sampler_name = style.live_sampler if is_live else style.sampler

--- a/ai_diffusion/model/model.py
+++ b/ai_diffusion/model/model.py
@@ -928,6 +928,9 @@ class DocumentModel(QObject, ObservableProperties):
     def generate_seed(self):
         self.seed = workflow.generate_seed()
 
+    def iterate_seed(self):
+        self.seed = workflow.iterate_seed(self.seed)
+
     def save_result(self, job_id: str, index: int):
         _save_job_result(self, self.jobs.find(job_id), index)
 
@@ -1322,8 +1325,11 @@ class LiveWorkspace(QObject, ObservableProperties):
             region_behavior = ApplyRegionBehavior.layer_group
         self.model.apply_result(self.result, params, behavior, region_behavior)
 
-        if settings.new_seed_after_apply:
+        if settings.new_seed_after_apply == random:
             self.model.generate_seed()
+
+        if settings.new_seed_after_apply == iterate:
+            self.model.iterate_seed()
 
     @property
     def result(self):

--- a/ai_diffusion/settings.py
+++ b/ai_diffusion/settings.py
@@ -122,6 +122,11 @@ class ImageFileFormat(Enum):
             return ImageFileFormat.jpeg
         return self
 
+class NewSeedMode(Enum):
+    disabled = (_("Disabled"), 0)
+    random = (_("Random"), 1)
+    iterate = (_("Iterate"), 2)
+
 
 class PerformancePresetSettings(NamedTuple):
     batch_size: int = 4
@@ -256,10 +261,10 @@ class Settings(QObject):
         _("NSFW Filter"), 0.0, _("Attempt to filter out images with explicit content")
     )
 
-    new_seed_after_apply: bool
+    new_seed_after_apply: NewSeedMode
     _new_seed_after_apply = Setting(
         _("Live: New Seed after Apply"),
-        False,
+        undefined,
         _("Pick a new seed after copying the result to the canvas in Live mode"),
     )
 


### PR DESCRIPTION
This PR is my attempt to add a feature for a quirk that bothered me. In live mode, I prefer punching in 1 as my seed number and iterating by 1 as I accept changes. This allows me to return to seeds that worked well just by using small simple numbers that are easy to remember.

At the time of this PR being created I have not added translations yet and I am still testing. Big fan of the project! First time contributing here. Not vibe coded, fwiw.