### PR TITLE
Update diffusers to 0.38.0 (security: GHSA-7wx4-6vff-v64p, GHSA-98h9-4798-4q5v)

### DIFF
--- a/ai_diffusion/backend/requirements/linux-cpu.txt
+++ b/ai_diffusion/backend/requirements/linux-cpu.txt
@@ -108,7 +108,7 @@ cymem==2.0.13
     #   spacy
     #   thinc
     # from https://pypi.org/simple
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ai_diffusion/backend/requirements/base.in
     # from https://pypi.org/simple
 einops==0.8.2

--- a/ai_diffusion/backend/requirements/linux-cuda.txt
+++ b/ai_diffusion/backend/requirements/linux-cuda.txt
@@ -117,7 +117,7 @@ cymem==2.0.13
     #   spacy
     #   thinc
     # from https://pypi.org/simple
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ai_diffusion/backend/requirements/base.in
     # from https://pypi.org/simple
 einops==0.8.2

--- a/ai_diffusion/backend/requirements/linux-cuda126.txt
+++ b/ai_diffusion/backend/requirements/linux-cuda126.txt
@@ -117,7 +117,7 @@ cymem==2.0.13
     #   spacy
     #   thinc
     # from https://pypi.org/simple
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ai_diffusion/backend/requirements/base.in
     # from https://pypi.org/simple
 einops==0.8.2

--- a/ai_diffusion/backend/requirements/linux-rocm.txt
+++ b/ai_diffusion/backend/requirements/linux-rocm.txt
@@ -108,7 +108,7 @@ cymem==2.0.13
     #   spacy
     #   thinc
     # from https://pypi.org/simple
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ai_diffusion/backend/requirements/base.in
     # from https://pypi.org/simple
 einops==0.8.2

--- a/ai_diffusion/backend/requirements/linux-xpu.txt
+++ b/ai_diffusion/backend/requirements/linux-xpu.txt
@@ -108,7 +108,7 @@ cymem==2.0.13
     #   spacy
     #   thinc
     # from https://pypi.org/simple
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ai_diffusion/backend/requirements/base.in
     # from https://pypi.org/simple
 dpcpp-cpp-rt==2025.3.2

--- a/ai_diffusion/backend/requirements/macos-cpu.txt
+++ b/ai_diffusion/backend/requirements/macos-cpu.txt
@@ -111,7 +111,7 @@ cymem==2.0.13
     #   spacy
     #   thinc
     # from https://pypi.org/simple
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ai_diffusion/backend/requirements/base.in
     # from https://pypi.org/simple
 einops==0.8.2

--- a/ai_diffusion/backend/requirements/macos-mps.txt
+++ b/ai_diffusion/backend/requirements/macos-mps.txt
@@ -111,7 +111,7 @@ cymem==2.0.13
     #   spacy
     #   thinc
     # from https://pypi.org/simple
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ai_diffusion/backend/requirements/base.in
     # from https://pypi.org/simple
 einops==0.8.2

--- a/ai_diffusion/backend/requirements/windows-cpu.txt
+++ b/ai_diffusion/backend/requirements/windows-cpu.txt
@@ -114,7 +114,7 @@ cymem==2.0.13
     #   spacy
     #   thinc
     # from https://pypi.org/simple
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ai_diffusion/backend/requirements/base.in
     # from https://pypi.org/simple
 einops==0.8.2

--- a/ai_diffusion/backend/requirements/windows-cuda.txt
+++ b/ai_diffusion/backend/requirements/windows-cuda.txt
@@ -114,7 +114,7 @@ cymem==2.0.13
     #   spacy
     #   thinc
     # from https://pypi.org/simple
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ai_diffusion/backend/requirements/base.in
     # from https://pypi.org/simple
 einops==0.8.2

--- a/ai_diffusion/backend/requirements/windows-cuda126.txt
+++ b/ai_diffusion/backend/requirements/windows-cuda126.txt
@@ -114,7 +114,7 @@ cymem==2.0.13
     #   spacy
     #   thinc
     # from https://pypi.org/simple
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ai_diffusion/backend/requirements/base.in
     # from https://pypi.org/simple
 einops==0.8.2

--- a/ai_diffusion/backend/requirements/windows-rocm.txt
+++ b/ai_diffusion/backend/requirements/windows-rocm.txt
@@ -113,7 +113,7 @@ cymem==2.0.13
     #   spacy
     #   thinc
     # from https://pypi.org/simple
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ai_diffusion/backend/requirements/base.in
     # from https://pypi.org/simple
 einops==0.8.2

--- a/ai_diffusion/backend/requirements/windows-xpu.txt
+++ b/ai_diffusion/backend/requirements/windows-xpu.txt
@@ -114,7 +114,7 @@ cymem==2.0.13
     #   spacy
     #   thinc
     # from https://pypi.org/simple
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ai_diffusion/backend/requirements/base.in
     # from https://pypi.org/simple
 dpcpp-cpp-rt==2025.3.2

--- a/ai_diffusion/backend/server_requirements.txt
+++ b/ai_diffusion/backend/server_requirements.txt
@@ -6,7 +6,7 @@ aiohttp==3.13.5
 albumentations==2.0.8
 argostranslate==1.11.0
 av==17.0.1
-diffusers==0.37.0
+diffusers==0.38.0
 einops==0.8.2
 filelock==3.29.0
 ftfy==6.3.1


### PR DESCRIPTION
Updates `diffusers` pinned version from 0.37.0/0.37.1 to 0.38.0 across all platform requirements files and `server_requirements.txt`.

## Advisories cleared

| ID | CVSS | Summary |
|---|---|---|
| [GHSA-7wx4-6vff-v64p](https://github.com/advisories/GHSA-7wx4-6vff-v64p) | 7.5 | TOCTOU Trust Remote Code Bypass |
| [GHSA-98h9-4798-4q5v](https://github.com/advisories/GHSA-98h9-4798-4q5v) | 8.8 | `trust_remote_code` bypass via `custom_pipeline` and local custom components |
| [PYSEC-2026-40](https://osv.dev/vulnerability/PYSEC-2026-40) | 8.8 | — |
| [PYSEC-2026-41](https://osv.dev/vulnerability/PYSEC-2026-41) | 8.8 | — |

All four are fixed in diffusers 0.38.0 per OSV.

## Verification

`osv-scanner` on `server_requirements.txt` before patch reports `diffusers==0.37.0` with the above advisories. After patching to 0.38.0, osv-scanner reports zero findings for diffusers. Remaining advisories in the scan are unrelated packages (aiohttp, pillow) outside the scope of this PR.

## Scope

Lockfile/requirements changes only — no source or logic changes. 0.38.0 is a minor release; no breaking changes documented in the [release notes](https://github.com/huggingface/diffusers/releases/tag/v0.38.0).