### PR TITLE
Fix websocket auth for managed/custom servers behind using bearer-token auth

### DIFF
--- a/ai_diffusion/backend/comfy_client.py
+++ b/ai_diffusion/backend/comfy_client.py
@@ -168,9 +168,9 @@ class ComfyClient(Client):
         # Retrieve system info
         self.device_info = DeviceInfo.parse(await self._get("system_stats"))
 
-        # Try to establish websockets connection
+        # Try to establish websockets connection which support token in server_authorization from settings.json
         wsurl = websocket_url(self.url)
-        wsargs = websocket_args(self._token)
+        wsargs = websocket_args(settings.server_authorization or self._token)
         try:
             async with websockets.connect(f"{wsurl}/ws?clientId={self._id}", **wsargs):
                 pass


### PR DESCRIPTION
## Problem
Connecting to a ComfyUI server protected by bearer-token
auth (e.g. ComfyUI-Login)  in managed or custom-server mode fails at the initial connection:

    ServerError: Could not establish websocket connection at ws://...:
    server rejected WebSocket connection: HTTP 200

HTTP requests authenticate correctly (Authorization header is set from
settings.server_authorization in __init__), but the websocket handshake in
connect() is rejected and redirected to the login page, which comes back as
HTTP 200 instead of a 101 upgrade.

## Cause
In ComfyClient.connect(), the initial websocket test builds its args from
self._token:

    wsargs = websocket_args(self._token)

self._token is only populated for cloud (Interstice) connections, so in
managed/custom mode it is empty and no Authorization header is sent on the
handshake. The ongoing listener in _listen() already uses the correct value
(settings.server_authorization).

## Fix
Use settings.server_authorization (falling back to self._token) so the
handshake carries the same bearer token as the HTTP requests and the
listener:

    wsargs = websocket_args(settings.server_authorization or self._token)

Tested against liusida/ComfyUI-Login; the connection now upgrades correctly.